### PR TITLE
OPHAKTKEH-133: informal emails sending endpoint

### DIFF
--- a/src/main/java/fi/oph/akt/api/clerk/EmailController.java
+++ b/src/main/java/fi/oph/akt/api/clerk/EmailController.java
@@ -1,7 +1,7 @@
 package fi.oph.akt.api.clerk;
 
 import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
-import fi.oph.akt.service.ClerkTranslatorService;
+import fi.oph.akt.service.email.ClerkEmailService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,12 +18,12 @@ import javax.validation.Valid;
 public class EmailController {
 
 	@Resource
-	private ClerkTranslatorService clerkTranslatorService;
+	private ClerkEmailService clerkEmailService;
 
 	@PostMapping("/informal")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void createInformalEmails(@Valid @RequestBody InformalEmailRequestDTO emailRequestDTO) {
-		clerkTranslatorService.createInformalEmails(emailRequestDTO);
+		clerkEmailService.createInformalEmails(emailRequestDTO);
 	}
 
 }

--- a/src/main/java/fi/oph/akt/api/clerk/EmailController.java
+++ b/src/main/java/fi/oph/akt/api/clerk/EmailController.java
@@ -1,6 +1,6 @@
 package fi.oph.akt.api.clerk;
 
-import fi.oph.akt.api.dto.clerk.InformalEmailDTO;
+import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
 import fi.oph.akt.service.ClerkTranslatorService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,8 +22,8 @@ public class EmailController {
 
 	@PostMapping("/informal")
 	@ResponseStatus(HttpStatus.CREATED)
-	public void createInformalEmails(@Valid @RequestBody InformalEmailDTO emailDTO) {
-		clerkTranslatorService.createInformalEmails(emailDTO.translatorIds(), emailDTO.subject(), emailDTO.body());
+	public void createInformalEmails(@Valid @RequestBody InformalEmailRequestDTO emailRequestDTO) {
+		clerkTranslatorService.createInformalEmails(emailRequestDTO);
 	}
 
 }

--- a/src/main/java/fi/oph/akt/api/clerk/EmailController.java
+++ b/src/main/java/fi/oph/akt/api/clerk/EmailController.java
@@ -1,0 +1,29 @@
+package fi.oph.akt.api.clerk;
+
+import fi.oph.akt.api.dto.clerk.InformalEmailDTO;
+import fi.oph.akt.service.ClerkTranslatorService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping(value = "/api/v1/clerk/email", produces = MediaType.APPLICATION_JSON_VALUE)
+public class EmailController {
+
+	@Resource
+	private ClerkTranslatorService clerkTranslatorService;
+
+	@PostMapping("/informal")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createInformalEmails(@Valid @RequestBody InformalEmailDTO emailDTO) {
+		clerkTranslatorService.createInformalEmails(emailDTO.translatorIds(), emailDTO.subject(), emailDTO.body());
+	}
+
+}

--- a/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailDTO.java
@@ -1,9 +1,0 @@
-package fi.oph.akt.api.dto.clerk;
-
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Size;
-import java.util.List;
-
-public record InformalEmailDTO(@NotEmpty @Size(max = 255) String subject, @NotEmpty @Size(max = 6000) String body,
-		@NotEmpty List<Long> translatorIds) {
-}

--- a/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailDTO.java
@@ -1,0 +1,9 @@
+package fi.oph.akt.api.dto.clerk;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+public record InformalEmailDTO(@NotEmpty @Size(max = 255) String subject, @NotEmpty @Size(max = 6000) String body,
+		@NotEmpty List<Long> translatorIds) {
+}

--- a/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
@@ -1,0 +1,15 @@
+package fi.oph.akt.api.dto.clerk;
+
+import lombok.Builder;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+public record InformalEmailRequestDTO(@NotEmpty @Size(max = 255) String subject,
+		@NotEmpty @Size(max = 6000) String body, @NotEmpty List<Long> translatorIds) {
+
+	@Builder
+	public InformalEmailRequestDTO {
+	}
+}

--- a/src/main/java/fi/oph/akt/model/EmailType.java
+++ b/src/main/java/fi/oph/akt/model/EmailType.java
@@ -2,6 +2,6 @@ package fi.oph.akt.model;
 
 public enum EmailType {
 
-	CONTACT_REQUEST
+	AUTHORISATION_EXPIRY, CONTACT_REQUEST, INFORMAL
 
 }

--- a/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
+++ b/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
@@ -249,11 +249,13 @@ public class ClerkTranslatorService {
 
 		translators.forEach(translator -> {
 			// @formatter:off
+			// TODO: replace recipient with translator's email address
 			EmailData emailData = EmailData.builder()
 					.sender("AKT")
 					.recipient("translator" + translator.getId() + "@test.fi")
 					.subject(emailRequestDTO.subject())
-					.body(emailRequestDTO.body()).build();
+					.body(emailRequestDTO.body())
+					.build();
 			// @formatter:on
 
 			emailService.saveEmail(EmailType.INFORMAL, emailData);

--- a/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
+++ b/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
@@ -7,8 +7,6 @@ import fi.oph.akt.api.dto.clerk.ClerkTranslatorAuthorisationDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorContactDetailsDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorResponseDTO;
-import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
-import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.Translator;
 import fi.oph.akt.onr.TranslatorDetails;
 import fi.oph.akt.onr.OnrServiceMock;
@@ -19,8 +17,6 @@ import fi.oph.akt.repository.AuthorisationTermRepository;
 import fi.oph.akt.repository.TranslatorAuthorisationProjection;
 import fi.oph.akt.repository.LanguagePairRepository;
 import fi.oph.akt.repository.TranslatorRepository;
-import fi.oph.akt.service.email.EmailData;
-import fi.oph.akt.service.email.EmailService;
 import fi.oph.akt.util.AuthorisationTermProjectionComparator;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -50,9 +46,6 @@ public class ClerkTranslatorService {
 
 	@Resource
 	private final AuthorisationTermRepository authorisationTermRepository;
-
-	@Resource
-	private final EmailService emailService;
 
 	@Resource
 	private final LanguagePairRepository languagePairRepository;
@@ -237,29 +230,6 @@ public class ClerkTranslatorService {
 
 	private List<String> getDistinctTowns(Collection<TranslatorDetails> translatorDetails) {
 		return translatorDetails.stream().map(TranslatorDetails::town).distinct().sorted().toList();
-	}
-
-	public void createInformalEmails(InformalEmailRequestDTO emailRequestDTO) {
-		final List<Long> distinctTranslatorIds = emailRequestDTO.translatorIds().stream().distinct().toList();
-		final List<Translator> translators = translatorRepository.findAllById(distinctTranslatorIds);
-
-		if (translators.size() != distinctTranslatorIds.size()) {
-			throw new IllegalArgumentException("Each translator by provided translatorIds not found");
-		}
-
-		translators.forEach(translator -> {
-			// @formatter:off
-			// TODO: replace recipient with translator's email address
-			EmailData emailData = EmailData.builder()
-					.sender("AKT")
-					.recipient("translator" + translator.getId() + "@test.fi")
-					.subject(emailRequestDTO.subject())
-					.body(emailRequestDTO.body())
-					.build();
-			// @formatter:on
-
-			emailService.saveEmail(EmailType.INFORMAL, emailData);
-		});
 	}
 
 }

--- a/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
+++ b/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
@@ -7,6 +7,7 @@ import fi.oph.akt.api.dto.clerk.ClerkTranslatorAuthorisationDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorContactDetailsDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorResponseDTO;
+import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
 import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.Translator;
 import fi.oph.akt.onr.TranslatorDetails;
@@ -238,8 +239,8 @@ public class ClerkTranslatorService {
 		return translatorDetails.stream().map(TranslatorDetails::town).distinct().sorted().toList();
 	}
 
-	public void createInformalEmails(List<Long> translatorIds, String subject, String body) {
-		final List<Long> distinctTranslatorIds = translatorIds.stream().distinct().toList();
+	public void createInformalEmails(InformalEmailRequestDTO emailRequestDTO) {
+		final List<Long> distinctTranslatorIds = emailRequestDTO.translatorIds().stream().distinct().toList();
 		final List<Translator> translators = translatorRepository.findAllById(distinctTranslatorIds);
 
 		if (translators.size() != distinctTranslatorIds.size()) {
@@ -251,8 +252,8 @@ public class ClerkTranslatorService {
 			EmailData emailData = EmailData.builder()
 					.sender("AKT")
 					.recipient("translator" + translator.getId() + "@test.fi")
-					.subject(subject)
-					.body(body).build();
+					.subject(emailRequestDTO.subject())
+					.body(emailRequestDTO.body()).build();
 			// @formatter:on
 
 			emailService.saveEmail(EmailType.INFORMAL, emailData);

--- a/src/main/java/fi/oph/akt/service/ContactRequestService.java
+++ b/src/main/java/fi/oph/akt/service/ContactRequestService.java
@@ -128,7 +128,8 @@ public class ContactRequestService {
 				.sender("AKT")
 				.recipient(recipient)
 				.subject("Yhteydenotto kääntäjärekisteristä")
-				.body(body).build();
+				.body(body)
+				.build();
 		// @formatter:on
 
 		emailService.saveEmail(EmailType.CONTACT_REQUEST, emailData);

--- a/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
+++ b/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
@@ -6,6 +6,7 @@ import fi.oph.akt.model.Translator;
 import fi.oph.akt.repository.TranslatorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
 import java.util.List;
@@ -20,6 +21,7 @@ public class ClerkEmailService {
 	@Resource
 	private final TranslatorRepository translatorRepository;
 
+	@Transactional
 	public void createInformalEmails(InformalEmailRequestDTO emailRequestDTO) {
 		final List<Long> distinctTranslatorIds = emailRequestDTO.translatorIds().stream().distinct().toList();
 		final List<Translator> translators = translatorRepository.findAllById(distinctTranslatorIds);

--- a/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
+++ b/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
@@ -1,0 +1,46 @@
+package fi.oph.akt.service.email;
+
+import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
+import fi.oph.akt.model.EmailType;
+import fi.oph.akt.model.Translator;
+import fi.oph.akt.repository.TranslatorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClerkEmailService {
+
+	@Resource
+	private final EmailService emailService;
+
+	@Resource
+	private final TranslatorRepository translatorRepository;
+
+	public void createInformalEmails(InformalEmailRequestDTO emailRequestDTO) {
+		final List<Long> distinctTranslatorIds = emailRequestDTO.translatorIds().stream().distinct().toList();
+		final List<Translator> translators = translatorRepository.findAllById(distinctTranslatorIds);
+
+		if (translators.size() != distinctTranslatorIds.size()) {
+			throw new IllegalArgumentException("Each translator by provided translatorIds not found");
+		}
+
+		translators.forEach(translator -> {
+			// @formatter:off
+            // TODO: replace recipient with translator's email address
+            EmailData emailData = EmailData.builder()
+                    .sender("AKT")
+                    .recipient("translator" + translator.getId() + "@test.fi")
+                    .subject(emailRequestDTO.subject())
+                    .body(emailRequestDTO.body())
+                    .build();
+            // @formatter:on
+
+			emailService.saveEmail(EmailType.INFORMAL, emailData);
+		});
+	}
+
+}

--- a/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -411,4 +411,13 @@
         <addUniqueConstraint tableName="meeting_date" columnNames="date"/>
     </changeSet>
 
+    <changeSet id="2022-01-04-add-new-email-types" author="mikhuttu">
+        <insert tableName="email_type">
+            <column name="name" value="AUTHORISATION_EXPIRY"/>
+        </insert>
+        <insert tableName="email_type">
+            <column name="name" value="INFORMAL"/>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -5,7 +5,6 @@ import fi.oph.akt.api.dto.clerk.ClerkLanguagePairDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorAuthorisationDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorResponseDTO;
-import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
 import fi.oph.akt.model.Authorisation;
 import fi.oph.akt.model.AuthorisationBasis;
 import fi.oph.akt.model.AuthorisationTerm;
@@ -17,16 +16,11 @@ import fi.oph.akt.repository.AuthorisationRepository;
 import fi.oph.akt.repository.AuthorisationTermRepository;
 import fi.oph.akt.repository.LanguagePairRepository;
 import fi.oph.akt.repository.TranslatorRepository;
-import fi.oph.akt.service.email.EmailData;
-import fi.oph.akt.service.email.EmailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.Resource;
@@ -37,11 +31,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @DataJpaTest
 @Import({ OnrServiceMock.class })
@@ -55,9 +45,6 @@ class ClerkTranslatorServiceTest {
 	@Resource
 	private AuthorisationTermRepository authorisationTermRepository;
 
-	@MockBean
-	private EmailService emailService;
-
 	@Resource
 	private LanguagePairRepository languagePairRepository;
 
@@ -70,13 +57,10 @@ class ClerkTranslatorServiceTest {
 	@Resource
 	private TestEntityManager entityManager;
 
-	@Captor
-	private ArgumentCaptor<EmailData> emailDataCaptor;
-
 	@BeforeEach
 	public void setup() {
 		clerkTranslatorService = new ClerkTranslatorService(authorisationRepository, authorisationTermRepository,
-				emailService, languagePairRepository, translatorRepository, onrServiceMock);
+				languagePairRepository, translatorRepository, onrServiceMock);
 	}
 
 	@Test
@@ -398,76 +382,6 @@ class ClerkTranslatorServiceTest {
 
 		assertEquals(term3BeginDate, authorisationDTO.term().beginDate());
 		assertEquals(term3EndDate, authorisationDTO.term().endDate());
-	}
-
-	@Test
-	public void createInformalEmailsShouldSaveEmailsToGivenTranslators() {
-		final MeetingDate meetingDate = Factory.meetingDate();
-		entityManager.persist(meetingDate);
-
-		IntStream.range(0, 3).forEach(n -> {
-			final Translator translator = Factory.translator();
-			final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
-			final LanguagePair languagePair = Factory.languagePair(authorisation);
-			final AuthorisationTerm authorisationTerm = Factory.authorisationTerm(authorisation);
-
-			entityManager.persist(translator);
-			entityManager.persist(authorisation);
-			entityManager.persist(languagePair);
-			entityManager.persist(authorisationTerm);
-		});
-
-		List<Long> translatorIds = translatorRepository.findAll().stream().map(Translator::getId).toList();
-
-		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(translatorIds)
-				.subject("otsikko").body("viesti").build();
-
-		clerkTranslatorService.createInformalEmails(emailRequestDTO);
-
-		verify(emailService, times(3)).saveEmail(any(), emailDataCaptor.capture());
-
-		List<EmailData> emailDatas = emailDataCaptor.getAllValues();
-
-		assertEquals(3, emailDatas.size());
-
-		emailDatas.forEach(emailData -> {
-			assertEquals("AKT", emailData.sender());
-			assertEquals("otsikko", emailData.subject());
-			assertEquals("viesti", emailData.body());
-		});
-	}
-
-	@Test
-	public void createInformalEmailsShouldSaveEmailToGivenTranslatorsWithDuplicateTranslatorIds() {
-		final MeetingDate meetingDate = Factory.meetingDate();
-		final Translator translator = Factory.translator();
-		final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
-		final LanguagePair languagePair = Factory.languagePair(authorisation);
-		final AuthorisationTerm authorisationTerm = Factory.authorisationTerm(authorisation);
-
-		entityManager.persist(meetingDate);
-		entityManager.persist(translator);
-		entityManager.persist(authorisation);
-		entityManager.persist(languagePair);
-		entityManager.persist(authorisationTerm);
-
-		Long tId = translatorRepository.findAll().get(0).getId();
-
-		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(tId, tId))
-				.subject("otsikko").body("viesti").build();
-
-		clerkTranslatorService.createInformalEmails(emailRequestDTO);
-
-		verify(emailService).saveEmail(any(), emailDataCaptor.capture());
-	}
-
-	@Test
-	public void createInformalEmailsShouldThrowIllegalArgumentExceptionForNonExistingTranslatorIds() {
-		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(1L))
-				.subject("otsikko").body("viesti").build();
-
-		assertThrows(IllegalArgumentException.class,
-				() -> clerkTranslatorService.createInformalEmails(emailRequestDTO));
 	}
 
 }

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -458,7 +458,7 @@ class ClerkTranslatorServiceTest {
 
 		clerkTranslatorService.createInformalEmails(emailRequestDTO);
 
-		verify(emailService, times(1)).saveEmail(any(), emailDataCaptor.capture());
+		verify(emailService).saveEmail(any(), emailDataCaptor.capture());
 	}
 
 	@Test

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -5,6 +5,7 @@ import fi.oph.akt.api.dto.clerk.ClerkLanguagePairDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorAuthorisationDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorResponseDTO;
+import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
 import fi.oph.akt.model.Authorisation;
 import fi.oph.akt.model.AuthorisationBasis;
 import fi.oph.akt.model.AuthorisationTerm;
@@ -418,7 +419,10 @@ class ClerkTranslatorServiceTest {
 
 		List<Long> translatorIds = translatorRepository.findAll().stream().map(Translator::getId).toList();
 
-		clerkTranslatorService.createInformalEmails(translatorIds, "testiotsikko", "testiviesti");
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(translatorIds)
+				.subject("otsikko").body("viesti").build();
+
+		clerkTranslatorService.createInformalEmails(emailRequestDTO);
 
 		verify(emailService, times(3)).saveEmail(any(), emailDataCaptor.capture());
 
@@ -428,8 +432,8 @@ class ClerkTranslatorServiceTest {
 
 		emailDatas.forEach(emailData -> {
 			assertEquals("AKT", emailData.sender());
-			assertEquals("testiotsikko", emailData.subject());
-			assertEquals("testiviesti", emailData.body());
+			assertEquals("otsikko", emailData.subject());
+			assertEquals("viesti", emailData.body());
 		});
 	}
 
@@ -449,15 +453,21 @@ class ClerkTranslatorServiceTest {
 
 		Long tId = translatorRepository.findAll().get(0).getId();
 
-		clerkTranslatorService.createInformalEmails(List.of(tId, tId), "testiotsikko", "testiviesti");
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(tId, tId))
+				.subject("otsikko").body("viesti").build();
+
+		clerkTranslatorService.createInformalEmails(emailRequestDTO);
 
 		verify(emailService, times(1)).saveEmail(any(), emailDataCaptor.capture());
 	}
 
 	@Test
 	public void createInformalEmailsShouldThrowIllegalArgumentExceptionForNonExistingTranslatorIds() {
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(1L))
+				.subject("otsikko").body("viesti").build();
+
 		assertThrows(IllegalArgumentException.class,
-				() -> clerkTranslatorService.createInformalEmails(List.of(1L), "testiotsikko", "testiviesti"));
+				() -> clerkTranslatorService.createInformalEmails(emailRequestDTO));
 	}
 
 }

--- a/src/test/java/fi/oph/akt/service/email/ClerkEmailServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/email/ClerkEmailServiceTest.java
@@ -1,0 +1,120 @@
+package fi.oph.akt.service.email;
+
+import fi.oph.akt.Factory;
+import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
+import fi.oph.akt.model.Authorisation;
+import fi.oph.akt.model.AuthorisationTerm;
+import fi.oph.akt.model.LanguagePair;
+import fi.oph.akt.model.MeetingDate;
+import fi.oph.akt.model.Translator;
+import fi.oph.akt.repository.TranslatorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DataJpaTest
+public class ClerkEmailServiceTest {
+
+	private ClerkEmailService clerkEmailService;
+
+	@MockBean
+	private EmailService emailService;
+
+	@Resource
+	private TranslatorRepository translatorRepository;
+
+	@Resource
+	private TestEntityManager entityManager;
+
+	@Captor
+	private ArgumentCaptor<EmailData> emailDataCaptor;
+
+	@BeforeEach
+	public void setup() {
+		clerkEmailService = new ClerkEmailService(emailService, translatorRepository);
+	}
+
+	@Test
+	public void createInformalEmailsShouldSaveEmailsToGivenTranslators() {
+		final MeetingDate meetingDate = Factory.meetingDate();
+		entityManager.persist(meetingDate);
+
+		IntStream.range(0, 3).forEach(n -> {
+			final Translator translator = Factory.translator();
+			final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
+			final LanguagePair languagePair = Factory.languagePair(authorisation);
+			final AuthorisationTerm authorisationTerm = Factory.authorisationTerm(authorisation);
+
+			entityManager.persist(translator);
+			entityManager.persist(authorisation);
+			entityManager.persist(languagePair);
+			entityManager.persist(authorisationTerm);
+		});
+
+		List<Long> translatorIds = translatorRepository.findAll().stream().map(Translator::getId).toList();
+
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(translatorIds)
+				.subject("otsikko").body("viesti").build();
+
+		clerkEmailService.createInformalEmails(emailRequestDTO);
+
+		verify(emailService, times(3)).saveEmail(any(), emailDataCaptor.capture());
+
+		List<EmailData> emailDatas = emailDataCaptor.getAllValues();
+
+		assertEquals(3, emailDatas.size());
+
+		emailDatas.forEach(emailData -> {
+			assertEquals("AKT", emailData.sender());
+			assertEquals("otsikko", emailData.subject());
+			assertEquals("viesti", emailData.body());
+		});
+	}
+
+	@Test
+	public void createInformalEmailsShouldSaveEmailToGivenTranslatorsWithDuplicateTranslatorIds() {
+		final MeetingDate meetingDate = Factory.meetingDate();
+		final Translator translator = Factory.translator();
+		final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
+		final LanguagePair languagePair = Factory.languagePair(authorisation);
+		final AuthorisationTerm authorisationTerm = Factory.authorisationTerm(authorisation);
+
+		entityManager.persist(meetingDate);
+		entityManager.persist(translator);
+		entityManager.persist(authorisation);
+		entityManager.persist(languagePair);
+		entityManager.persist(authorisationTerm);
+
+		Long tId = translatorRepository.findAll().get(0).getId();
+
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(tId, tId))
+				.subject("otsikko").body("viesti").build();
+
+		clerkEmailService.createInformalEmails(emailRequestDTO);
+
+		verify(emailService).saveEmail(any(), emailDataCaptor.capture());
+	}
+
+	@Test
+	public void createInformalEmailsShouldThrowIllegalArgumentExceptionForNonExistingTranslatorIds() {
+		InformalEmailRequestDTO emailRequestDTO = InformalEmailRequestDTO.builder().translatorIds(List.of(1L))
+				.subject("otsikko").body("viesti").build();
+
+		assertThrows(IllegalArgumentException.class, () -> clerkEmailService.createInformalEmails(emailRequestDTO));
+	}
+
+}


### PR DESCRIPTION
Endpoint for sending informal emails to selected translators. Tested this locally by commenting out the authorization via role VIRKAILIJA under WebSecurityConfig.

Implemented on top of https://github.com/Opetushallitus/akt/pull/70/files because ClerkTranslatorService seemed like a suitable place for putting the service level logic.