### PR TITLE
OPHAKTKEH-132: authorisation expiry email creator

### DIFF
--- a/src/main/java/fi/oph/akt/repository/AuthorisationExpiryDataProjection.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationExpiryDataProjection.java
@@ -1,0 +1,4 @@
+package fi.oph.akt.repository;
+
+public record AuthorisationExpiryDataProjection(long authorisationId, long translatorId) {
+}

--- a/src/main/java/fi/oph/akt/repository/AuthorisationTermReminderRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationTermReminderRepository.java
@@ -1,0 +1,10 @@
+package fi.oph.akt.repository;
+
+import fi.oph.akt.model.AuthorisationTermReminder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthorisationTermReminderRepository extends JpaRepository<AuthorisationTermReminder, Long> {
+
+}

--- a/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -13,5 +14,24 @@ public interface AuthorisationTermRepository extends JpaRepository<Authorisation
 	@Query("SELECT new fi.oph.akt.repository.AuthorisationTermProjection(at.authorisation.id, at.beginDate, at.endDate)"
 			+ " FROM AuthorisationTerm at")
 	List<AuthorisationTermProjection> listAuthorisationTermProjections();
+
+	// @formatter:off
+	@Query("SELECT at.id"
+			+ " FROM AuthorisationTerm at"
+			+ " LEFT JOIN at.reminders atr"
+			+ " WHERE at.endDate BETWEEN ?1 AND ?2"
+			+ " GROUP BY at.id, atr.id"
+			+ " HAVING COUNT(atr.id) <= ?3")
+	// @formatter:on
+	List<Long> findAuthorisationTermsExpiringBetween(LocalDate start, LocalDate end, long maxReminderCount);
+
+	// @formatter:off
+	@Query("SELECT new fi.oph.akt.repository.AuthorisationExpiryDataProjection(a.id, t.id)"
+			+ " FROM Translator t"
+			+ " JOIN t.authorisations a"
+			+ " JOIN a.terms at"
+			+ " WHERE at.id = ?1")
+	// @formatter:on
+	AuthorisationExpiryDataProjection getExpiryDataProjection(long authorisationTermId);
 
 }

--- a/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -21,9 +22,10 @@ public interface AuthorisationTermRepository extends JpaRepository<Authorisation
 			+ " LEFT JOIN at.reminders atr"
 			+ " WHERE at.endDate BETWEEN ?1 AND ?2"
 			+ " GROUP BY at.id, atr.id"
-			+ " HAVING COUNT(atr.id) <= ?3")
+			+ " HAVING COUNT(atr.id) = 0 OR MAX(atr.createdAt) < ?3")
 	// @formatter:on
-	List<Long> findAuthorisationTermsExpiringBetween(LocalDate start, LocalDate end, long maxReminderCount);
+	List<Long> findExpiringAuthorisationTerms(LocalDate betweenStart, LocalDate betweenEnd,
+			LocalDateTime previousReminderSentBefore);
 
 	// @formatter:off
 	@Query("SELECT new fi.oph.akt.repository.AuthorisationExpiryDataProjection(a.id, t.id)"

--- a/src/main/java/fi/oph/akt/repository/LanguagePairRepository.java
+++ b/src/main/java/fi/oph/akt/repository/LanguagePairRepository.java
@@ -26,6 +26,9 @@ public interface LanguagePairRepository extends JpaRepository<LanguagePair, Long
 	// @formatter:on
 	List<TranslatorLanguagePairProjection> findTranslatorLanguagePairsForPublicListing();
 
+	@Query("SELECT lp FROM LanguagePair lp WHERE lp.authorisation.id = ?1")
+	List<LanguagePair> findByAuthorisation(Long authorisationId);
+
 	@Query("SELECT DISTINCT lp.fromLang FROM LanguagePair lp ORDER BY lp.fromLang")
 	List<String> getDistinctFromLangs();
 

--- a/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
+++ b/src/main/java/fi/oph/akt/service/email/ClerkEmailService.java
@@ -1,28 +1,55 @@
 package fi.oph.akt.service.email;
 
 import fi.oph.akt.api.dto.clerk.InformalEmailRequestDTO;
+import fi.oph.akt.model.AuthorisationTerm;
+import fi.oph.akt.model.AuthorisationTermReminder;
+import fi.oph.akt.model.Email;
 import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.Translator;
+import fi.oph.akt.repository.AuthorisationExpiryDataProjection;
+import fi.oph.akt.repository.AuthorisationTermReminderRepository;
+import fi.oph.akt.repository.AuthorisationTermRepository;
+import fi.oph.akt.repository.EmailRepository;
+import fi.oph.akt.repository.LanguagePairRepository;
 import fi.oph.akt.repository.TranslatorRepository;
+import fi.oph.akt.util.TemplateRenderer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ClerkEmailService {
 
 	@Resource
+	private final AuthorisationTermReminderRepository authorisationTermReminderRepository;
+
+	@Resource
+	private final AuthorisationTermRepository authorisationTermRepository;
+
+	@Resource
+	private final EmailRepository emailRepository;
+
+	@Resource
 	private final EmailService emailService;
+
+	@Resource
+	private final LanguagePairRepository languagePairRepository;
+
+	@Resource
+	private final TemplateRenderer templateRenderer;
 
 	@Resource
 	private final TranslatorRepository translatorRepository;
 
 	@Transactional
-	public void createInformalEmails(InformalEmailRequestDTO emailRequestDTO) {
+	public void createInformalEmails(final InformalEmailRequestDTO emailRequestDTO) {
 		final List<Long> distinctTranslatorIds = emailRequestDTO.translatorIds().stream().distinct().toList();
 		final List<Translator> translators = translatorRepository.findAllById(distinctTranslatorIds);
 
@@ -31,18 +58,72 @@ public class ClerkEmailService {
 		}
 
 		translators.forEach(translator -> {
-			// @formatter:off
-            // TODO: replace recipient with translator's email address
-            EmailData emailData = EmailData.builder()
-                    .sender("AKT")
-                    .recipient("translator" + translator.getId() + "@test.fi")
-                    .subject(emailRequestDTO.subject())
-                    .body(emailRequestDTO.body())
-                    .build();
-            // @formatter:on
-
-			emailService.saveEmail(EmailType.INFORMAL, emailData);
+			// TODO: replace recipient with translator's email address
+			createEmail("translator" + translator.getId() + "@test.fi", emailRequestDTO.subject(),
+					emailRequestDTO.body(), EmailType.INFORMAL);
 		});
+	}
+
+	private Long createEmail(final String recipient, final String subject, final String body,
+			final EmailType emailType) {
+
+		// @formatter:off
+		final EmailData emailData = EmailData.builder()
+				.sender("AKT")
+				.recipient(recipient)
+				.subject(subject)
+				.body(body)
+				.build();
+		// @formatter:on
+
+		return emailService.saveEmail(emailType, emailData);
+	}
+
+	@Transactional
+	public void createAuthorisationExpiryEmail(final long authorisationTermId) {
+		authorisationTermRepository.findById(authorisationTermId).ifPresent(this::createAuthorisationExpiryData);
+	}
+
+	private void createAuthorisationExpiryData(final AuthorisationTerm authorisationTerm) {
+		final AuthorisationExpiryDataProjection expiryData = authorisationTermRepository
+				.getExpiryDataProjection(authorisationTerm.getId());
+
+		final String emailBody = getAuthorisationExpiryEmailBody(expiryData.authorisationId(),
+				authorisationTerm.getEndDate());
+
+		// TODO: replace recipient with translator's email address
+		final Long emailId = createEmail("translator" + expiryData.translatorId() + "@test.fi",
+				"Auktorisointisi on päättymässä", emailBody, EmailType.AUTHORISATION_EXPIRY);
+
+		final Email email = emailRepository.getById(emailId);
+
+		createAuthorisationTermReminder(authorisationTerm, email);
+	}
+
+	private String getAuthorisationExpiryEmailBody(final Long authorisationId, final LocalDate termEndDate) {
+		// @formatter:off
+		final List<String> languagePairs = languagePairRepository
+				.findByAuthorisation(authorisationId)
+				.stream()
+				.map(lp -> lp.getFromLang().toLowerCase() + " - " + lp.getToLang().toLowerCase())
+				.toList();
+
+		final Map<String, Object> templateParams = Map.of(
+				"expiryDate", termEndDate.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")),
+				"languagePairs", languagePairs,
+				"contactEmail", "auktoris@oph.fi"
+		);
+		// @formatter:on
+
+		return templateRenderer.renderAuthorisationExpiryEmailBody(templateParams);
+	}
+
+	private void createAuthorisationTermReminder(final AuthorisationTerm authorisationTerm, final Email email) {
+		final AuthorisationTermReminder reminder = new AuthorisationTermReminder();
+		reminder.setAuthorisationTerm(authorisationTerm);
+		reminder.setEmail(email);
+
+		authorisationTermReminderRepository.save(reminder);
 	}
 
 }

--- a/src/main/java/fi/oph/akt/service/email/EmailService.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailService.java
@@ -33,6 +33,7 @@ public class EmailService {
 		email.setRecipient(emailData.recipient());
 		email.setSubject(emailData.subject());
 		email.setBody(emailData.body());
+
 		return emailRepository.saveAndFlush(email).getId();
 	}
 

--- a/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
+++ b/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
@@ -1,0 +1,46 @@
+package fi.oph.akt.service.email;
+
+import fi.oph.akt.repository.AuthorisationTermRepository;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class ExpiringAuthorisationsEmailCreator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExpiringAuthorisationsEmailCreator.class);
+
+	private static final String FIXED_DELAY = "PT1M"; // TODO: change to "PT12H"
+
+	private static final String INITIAL_DELAY = "PT1S"; // TODO: change to "PT1H"
+
+	private static final String LOCK_AT_LEAST = "PT10S";
+
+	private static final String LOCK_AT_MOST = "PT2H";
+
+	@Resource
+	private final AuthorisationTermRepository termRepository;
+
+	@Resource
+	private final ClerkEmailService clerkEmailService;
+
+	@Scheduled(fixedDelayString = FIXED_DELAY, initialDelayString = INITIAL_DELAY)
+	@SchedulerLock(name = "pollExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+	public void pollExpiringAuthorisations() {
+		LOG.debug("pollExpiringAuthorisations");
+		final LocalDate expiryStart = LocalDate.now();
+		final LocalDate expiryEnd = expiryStart.plusMonths(3);
+		final long maxReminderCount = 0;
+
+		termRepository.findAuthorisationTermsExpiringBetween(expiryStart, expiryEnd, maxReminderCount)
+				.forEach(clerkEmailService::createAuthorisationExpiryEmail);
+	}
+
+}

--- a/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
+++ b/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -35,11 +36,11 @@ public class ExpiringAuthorisationsEmailCreator {
 	@SchedulerLock(name = "pollExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
 	public void pollExpiringAuthorisations() {
 		LOG.debug("pollExpiringAuthorisations");
-		final LocalDate expiryStart = LocalDate.now();
-		final LocalDate expiryEnd = expiryStart.plusMonths(3);
-		final long maxReminderCount = 0;
+		final LocalDate expiryBetweenStart = LocalDate.now();
+		final LocalDate expiryBetweenEnd = expiryBetweenStart.plusMonths(3);
+		final LocalDateTime previousReminderSentBefore = expiryBetweenStart.minusMonths(4).atStartOfDay();
 
-		termRepository.findAuthorisationTermsExpiringBetween(expiryStart, expiryEnd, maxReminderCount)
+		termRepository.findExpiringAuthorisationTerms(expiryBetweenStart, expiryBetweenEnd, previousReminderSentBefore)
 				.forEach(clerkEmailService::createAuthorisationExpiryEmail);
 	}
 

--- a/src/main/java/fi/oph/akt/util/TemplateRenderer.java
+++ b/src/main/java/fi/oph/akt/util/TemplateRenderer.java
@@ -13,10 +13,19 @@ public class TemplateRenderer {
 
 	private final TemplateEngine templateEngine;
 
+	public String renderAuthorisationExpiryEmailBody(final Map<String, Object> params) {
+		return renderTemplate("authorisation-expiry", params);
+	}
+
 	public String renderContactRequestEmailBody(final Map<String, Object> params) {
+		return renderTemplate("contact-request", params);
+	}
+
+	private String renderTemplate(final String template, final Map<String, Object> params) {
 		final Context context = new Context();
 		context.setVariables(params);
-		return templateEngine.process("contact-request", context);
+
+		return templateEngine.process(template, context);
 	}
 
 }

--- a/src/main/resources/email-templates/authorisation-expiry.html
+++ b/src/main/resources/email-templates/authorisation-expiry.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="fi">
+    <body>
+        <p>
+            Hei,
+        </p>
+        <p>
+            Oikeutesi toimia auktorisoituna kääntäjänä päättyy [[${expiryDate}]]. Oikeutesi on päättymässä seuraavien kieliparien osalta:
+        </p>
+
+        <ul>
+            <li th:each="langPair : ${languagePairs}">[[${langPair}]]</li>
+        </ul>
+
+        <p>
+            Jatkaaksesi oikeuttasi toimia auktorisoituna kääntäjänä, ja jotta sinut voi jatkossakin löytää rekisteristämme, otathan yhteyttä meihin osoitteessa [[${contactEmail}]].
+        </p>
+        <br/>
+
+        <p>
+            Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
+        </p>
+        <p>
+            Ystävällisin terveisin<br/>
+            Opintopolku
+        </p>
+    </body>
+</html>

--- a/src/test/java/fi/oph/akt/Factory.java
+++ b/src/test/java/fi/oph/akt/Factory.java
@@ -3,6 +3,7 @@ package fi.oph.akt;
 import fi.oph.akt.model.Authorisation;
 import fi.oph.akt.model.AuthorisationBasis;
 import fi.oph.akt.model.AuthorisationTerm;
+import fi.oph.akt.model.AuthorisationTermReminder;
 import fi.oph.akt.model.Email;
 import fi.oph.akt.model.EmailType;
 import fi.oph.akt.model.LanguagePair;
@@ -64,7 +65,16 @@ public class Factory {
 		email.setRecipient("ville.vastaanottaja@invalid");
 		email.setSubject("Spostin otsikko");
 		email.setBody("Sisältö on tässä");
+
 		return email;
+	}
+
+	public static AuthorisationTermReminder authorisationTermReminder(final AuthorisationTerm term, final Email email) {
+		final AuthorisationTermReminder reminder = new AuthorisationTermReminder();
+		reminder.setAuthorisationTerm(term);
+		reminder.setEmail(email);
+
+		return reminder;
 	}
 
 }

--- a/src/test/java/fi/oph/akt/service/email/EmailServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/email/EmailServiceTest.java
@@ -52,21 +52,21 @@ class EmailServiceTest {
 	public void saveEmailTest() {
 		final EmailData emailData = EmailData.builder().sender("lähettäjä").recipient("vastaanottaja@invalid")
 				.subject("testiotsikko").body("testiviesti").build();
-		final Long savedId = emailService.saveEmail(EmailType.CONTACT_REQUEST, emailData);
 
-		final List<Email> all = emailRepository.findAll();
-		assertEquals(1, all.size());
+		final Long emailId = emailService.saveEmail(EmailType.CONTACT_REQUEST, emailData);
+		final Email email = emailRepository.getById(emailId);
 
-		final Email persistedEmail = all.get(0);
-		assertEquals(savedId, persistedEmail.getId());
-		assertEquals(EmailType.CONTACT_REQUEST, persistedEmail.getEmailType());
-		assertEquals("lähettäjä", persistedEmail.getSender());
-		assertEquals("vastaanottaja@invalid", persistedEmail.getRecipient());
-		assertEquals("testiotsikko", persistedEmail.getSubject());
-		assertEquals("testiviesti", persistedEmail.getBody());
-		assertNull(persistedEmail.getSentAt());
-		assertNull(persistedEmail.getError());
-		assertNull(persistedEmail.getExtId());
+		assertEquals(EmailType.CONTACT_REQUEST, email.getEmailType());
+		assertEquals("lähettäjä", email.getSender());
+		assertEquals("vastaanottaja@invalid", email.getRecipient());
+		assertEquals("testiotsikko", email.getSubject());
+		assertEquals("testiviesti", email.getBody());
+		assertNull(email.getSentAt());
+		assertNull(email.getError());
+		assertNull(email.getExtId());
+
+		final List<Email> allEmails = emailRepository.findAll();
+		assertEquals(1, allEmails.size());
 	}
 
 	@Test

--- a/src/test/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreatorTest.java
+++ b/src/test/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreatorTest.java
@@ -1,0 +1,107 @@
+package fi.oph.akt.service.email;
+
+import fi.oph.akt.Factory;
+import fi.oph.akt.model.Authorisation;
+import fi.oph.akt.model.AuthorisationTerm;
+import fi.oph.akt.model.AuthorisationTermReminder;
+import fi.oph.akt.model.Email;
+import fi.oph.akt.model.EmailType;
+import fi.oph.akt.model.MeetingDate;
+import fi.oph.akt.model.Translator;
+import fi.oph.akt.repository.AuthorisationTermRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import javax.annotation.Resource;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DataJpaTest
+public class ExpiringAuthorisationsEmailCreatorTest {
+
+	private ExpiringAuthorisationsEmailCreator emailCreator;
+
+	@Resource
+	private AuthorisationTermRepository authorisationTermRepository;
+
+	@MockBean
+	private ClerkEmailService clerkEmailService;
+
+	@Resource
+	private TestEntityManager entityManager;
+
+	@Captor
+	private ArgumentCaptor<Long> longCaptor;
+
+	@BeforeEach
+	public void setup() {
+		emailCreator = new ExpiringAuthorisationsEmailCreator(authorisationTermRepository, clerkEmailService);
+	}
+
+	@Test
+	public void testPollExpiringAuthorisations() {
+		final MeetingDate meetingDate = Factory.meetingDate();
+		entityManager.persist(meetingDate);
+
+		final AuthorisationTerm term1 = createTerm(meetingDate, LocalDate.now());
+		final AuthorisationTerm term2 = createTerm(meetingDate, LocalDate.now().plusDays(10));
+		final AuthorisationTerm term3 = createTerm(meetingDate, LocalDate.now().plusMonths(3));
+
+		final AuthorisationTerm pastTerm = createTerm(meetingDate, LocalDate.now().minusDays(1));
+		final AuthorisationTerm futureTerm = createTerm(meetingDate, LocalDate.now().plusMonths(3).plusDays(1));
+
+		final AuthorisationTerm remindedTerm1 = createTerm(meetingDate, LocalDate.now().plusMonths(1));
+		createAuthorisationTermReminder(remindedTerm1);
+
+		final AuthorisationTerm remindedTerm2 = createTerm(meetingDate, LocalDate.now().plusMonths(2));
+		createAuthorisationTermReminder(remindedTerm2);
+		createAuthorisationTermReminder(remindedTerm2);
+
+		emailCreator.pollExpiringAuthorisations();
+
+		verify(clerkEmailService, times(3)).createAuthorisationExpiryEmail(longCaptor.capture());
+
+		final List<Long> expiringTermIds = longCaptor.getAllValues();
+
+		assertEquals(3, expiringTermIds.size());
+
+		assertTrue(expiringTermIds.contains(term1.getId()));
+		assertTrue(expiringTermIds.contains(term2.getId()));
+		assertTrue(expiringTermIds.contains(term3.getId()));
+	}
+
+	private AuthorisationTerm createTerm(MeetingDate meetingDate, LocalDate endDate) {
+		final Translator translator = Factory.translator();
+		final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
+		final AuthorisationTerm authorisationTerm = Factory.authorisationTerm(authorisation);
+
+		authorisationTerm.setBeginDate(endDate.minusYears(1));
+		authorisationTerm.setEndDate(endDate);
+
+		entityManager.persist(meetingDate);
+		entityManager.persist(translator);
+		entityManager.persist(authorisation);
+		entityManager.persist(authorisationTerm);
+
+		return authorisationTerm;
+	}
+
+	private void createAuthorisationTermReminder(AuthorisationTerm term) {
+		final Email email = Factory.email(EmailType.AUTHORISATION_EXPIRY);
+		entityManager.persist(email);
+
+		final AuthorisationTermReminder reminder = Factory.authorisationTermReminder(term, email);
+		entityManager.persist(reminder);
+	}
+
+}


### PR DESCRIPTION
Skeludoitu prosessi, joka lähettää `authorisation-expiry` mailia kääntäjille, joille on 3kk sisällä umpeutumassa jonkin auktorisoinnin voimassaolo. Mailissa listataan tällä hetkellä myös kieliparit (vain kielikoodeina), joita umpeutumassa oleva auktorisointi koskee. Mikäli voimassaoloa kohti on jo lähetetty voimassaolomuistutus, ei sellaista lähetetä uudelleen.

Ohessa viesti, joka generoitu kirjoittamalla manuaalisesti untuvan kannassa voimassaololle `authorisation_term_id: 48102` päättymispäiväksi `2022-03-31`: https://virkailija.untuvaopintopolku.fi/viestintapalvelu-ui/#/reportMessages/view/2428415

Muokattu:
Commitissa 15e044a poistettu turha rivinvaihto kieliparien listauksen perästä, joka ei näy oheisessa mailissa.