### PR TITLE
OPHAKTKEH-167: initial endpoint for translator view data

### DIFF
--- a/src/main/java/fi/oph/akt/api/clerk/ClerkTranslatorController.java
+++ b/src/main/java/fi/oph/akt/api/clerk/ClerkTranslatorController.java
@@ -2,11 +2,15 @@ package fi.oph.akt.api.clerk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import fi.oph.akt.api.dto.LanguageDTO;
+import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorResponseDTO;
 import fi.oph.akt.service.ClerkTranslatorService;
 import fi.oph.akt.service.LanguageService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +30,12 @@ public class ClerkTranslatorController {
 	@GetMapping(path = "")
 	public ClerkTranslatorResponseDTO list() {
 		return clerkTranslatorService.listTranslators();
+	}
+
+	@GetMapping(path = "/{id}")
+	public ResponseEntity<ClerkTranslatorDTO> get(@PathVariable Long id) {
+		return clerkTranslatorService.findTranslator(id).map(dto -> new ResponseEntity<>(dto, HttpStatus.OK))
+				.orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
 	}
 
 	@GetMapping(path = "/all-languages")

--- a/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorAuthorisationDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorAuthorisationDTO.java
@@ -4,9 +4,11 @@ import fi.oph.akt.model.AuthorisationBasis;
 import lombok.Builder;
 import lombok.NonNull;
 
+import java.time.LocalDate;
 import java.util.List;
 
-public record ClerkTranslatorAuthorisationDTO(@NonNull AuthorisationBasis basis, AuthorisationTermDTO term,
+public record ClerkTranslatorAuthorisationDTO(@NonNull AuthorisationBasis basis, LocalDate autDate, String kktCheck,
+		LocalDate virDate, LocalDate assuranceDate, LocalDate meetingDate, List<AuthorisationTermDTO> terms,
 		@NonNull List<ClerkLanguagePairDTO> languagePairs) {
 
 	// Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/repository/AuthorisationMeetingDateProjection.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationMeetingDateProjection.java
@@ -1,0 +1,6 @@
+package fi.oph.akt.repository;
+
+import java.time.LocalDate;
+
+public record AuthorisationMeetingDateProjection(long authorisationId, LocalDate date) {
+}

--- a/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationTermRepository.java
@@ -14,4 +14,8 @@ public interface AuthorisationTermRepository extends JpaRepository<Authorisation
 			+ " FROM AuthorisationTerm at")
 	List<AuthorisationTermProjection> listAuthorisationTermProjections();
 
+	@Query("SELECT new fi.oph.akt.repository.AuthorisationTermProjection(at.authorisation.id, at.beginDate, at.endDate)"
+			+ " FROM AuthorisationTerm at WHERE at.authorisation.id IN ?1")
+	List<AuthorisationTermProjection> listAuthorisationTermProjectionsByAuthorisations(Iterable<Long> authorisationIds);
+
 }

--- a/src/main/java/fi/oph/akt/repository/LanguagePairRepository.java
+++ b/src/main/java/fi/oph/akt/repository/LanguagePairRepository.java
@@ -14,6 +14,11 @@ public interface LanguagePairRepository extends JpaRepository<LanguagePair, Long
 			+ " FROM LanguagePair lp")
 	List<AuthorisationLanguagePairProjection> listAuthorisationLanguagePairProjections();
 
+	@Query("SELECT new fi.oph.akt.repository.AuthorisationLanguagePairProjection(lp.authorisation.id, lp.fromLang, lp.toLang, lp.permissionToPublish)"
+			+ " FROM LanguagePair lp WHERE lp.authorisation.id IN ?1")
+	List<AuthorisationLanguagePairProjection> listAuthorisationLanguagePairProjectionsByAuthorisations(
+			Iterable<Long> authorisationIds);
+
 	@Query("SELECT new fi.oph.akt.repository.TranslatorLanguagePairProjection(t.id, lp.fromLang, lp.toLang) FROM LanguagePair lp"
 			+ " JOIN lp.authorisation a JOIN a.translator t WHERE lp.permissionToPublish=true AND t.id IN ?1")
 	List<TranslatorLanguagePairProjection> findTranslatorLanguagePairsForPublicListing(Iterable<Long> translatorIds);

--- a/src/main/java/fi/oph/akt/repository/MeetingDateRepository.java
+++ b/src/main/java/fi/oph/akt/repository/MeetingDateRepository.java
@@ -1,0 +1,22 @@
+package fi.oph.akt.repository;
+
+import fi.oph.akt.model.MeetingDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MeetingDateRepository extends JpaRepository<MeetingDate, Long> {
+
+	// @formatter:off
+	@Query("SELECT new fi.oph.akt.repository.AuthorisationMeetingDateProjection(a.id, md.date)"
+			+ " FROM MeetingDate md"
+			+ " JOIN md.authorisations a"
+			+ " WHERE a.id IN ?1")
+	// @formatter:on
+	List<AuthorisationMeetingDateProjection> listAuthorisationMeetingDatesByAuthorisations(
+			Iterable<Long> authorisationIds);
+
+}

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -1,6 +1,7 @@
 package fi.oph.akt.service;
 
 import fi.oph.akt.Factory;
+import fi.oph.akt.api.dto.clerk.AuthorisationTermDTO;
 import fi.oph.akt.api.dto.clerk.ClerkLanguagePairDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorAuthorisationDTO;
 import fi.oph.akt.api.dto.clerk.ClerkTranslatorDTO;
@@ -15,6 +16,7 @@ import fi.oph.akt.onr.OnrServiceMock;
 import fi.oph.akt.repository.AuthorisationRepository;
 import fi.oph.akt.repository.AuthorisationTermRepository;
 import fi.oph.akt.repository.LanguagePairRepository;
+import fi.oph.akt.repository.MeetingDateRepository;
 import fi.oph.akt.repository.TranslatorRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +51,9 @@ class ClerkTranslatorServiceTest {
 	private LanguagePairRepository languagePairRepository;
 
 	@Resource
+	private MeetingDateRepository meetingDateRepository;
+
+	@Resource
 	private TranslatorRepository translatorRepository;
 
 	@Autowired
@@ -60,7 +65,7 @@ class ClerkTranslatorServiceTest {
 	@BeforeEach
 	public void setup() {
 		clerkTranslatorService = new ClerkTranslatorService(authorisationRepository, authorisationTermRepository,
-				languagePairRepository, translatorRepository, onrServiceMock);
+				languagePairRepository, meetingDateRepository, translatorRepository, onrServiceMock);
 	}
 
 	@Test
@@ -154,23 +159,25 @@ class ClerkTranslatorServiceTest {
 		entityManager.persist(authorisationTerm);
 
 		final ClerkTranslatorResponseDTO responseDTO = clerkTranslatorService.listTranslators();
-		List<ClerkTranslatorDTO> translatorDTOS = responseDTO.translators();
 
+		List<ClerkTranslatorDTO> translatorDTOS = responseDTO.translators();
 		assertEquals(1, translatorDTOS.size());
 
 		ClerkTranslatorDTO translatorDTO = translatorDTOS.get(0);
-		List<ClerkTranslatorAuthorisationDTO> authorisationDTOS = translatorDTO.authorisations();
 
+		List<ClerkTranslatorAuthorisationDTO> authorisationDTOS = translatorDTO.authorisations();
 		assertEquals(1, authorisationDTOS.size());
 
 		ClerkTranslatorAuthorisationDTO authorisationDTO = authorisationDTOS.get(0);
-
 		assertEquals(AuthorisationBasis.AUT, authorisationDTO.basis());
-		assertEquals(termBeginDate, authorisationDTO.term().beginDate());
-		assertEquals(termEndDate, authorisationDTO.term().endDate());
+
+		List<AuthorisationTermDTO> termDTOS = authorisationDTO.terms();
+		assertEquals(1, termDTOS.size());
+
+		assertEquals(termBeginDate, termDTOS.get(0).beginDate());
+		assertEquals(termEndDate, termDTOS.get(0).endDate());
 
 		List<ClerkLanguagePairDTO> languagePairDTOS = authorisationDTO.languagePairs();
-
 		assertEquals(3, languagePairDTOS.size());
 
 		// @formatter:off
@@ -220,8 +227,8 @@ class ClerkTranslatorServiceTest {
 		ClerkTranslatorAuthorisationDTO authorisationDTO = responseDTO.translators().get(0).authorisations().get(0);
 
 		assertEquals(AuthorisationBasis.KKT, authorisationDTO.basis());
-		assertEquals(termBeginDate, authorisationDTO.term().beginDate());
-		assertEquals(termEndDate, authorisationDTO.term().endDate());
+		assertEquals(termBeginDate, authorisationDTO.terms().get(0).beginDate());
+		assertEquals(termEndDate, authorisationDTO.terms().get(0).endDate());
 	}
 
 	@Test
@@ -251,8 +258,8 @@ class ClerkTranslatorServiceTest {
 		ClerkTranslatorAuthorisationDTO authorisationDTO = responseDTO.translators().get(0).authorisations().get(0);
 
 		assertEquals(AuthorisationBasis.VIR, authorisationDTO.basis());
-		assertEquals(termBeginDate, authorisationDTO.term().beginDate());
-		assertNull(authorisationDTO.term().endDate());
+		assertEquals(termBeginDate, authorisationDTO.terms().get(0).beginDate());
+		assertNull(authorisationDTO.terms().get(0).endDate());
 	}
 
 	@Test
@@ -274,7 +281,7 @@ class ClerkTranslatorServiceTest {
 
 		ClerkTranslatorAuthorisationDTO authorisationDTO = responseDTO.translators().get(0).authorisations().get(0);
 
-		assertNull(authorisationDTO.term());
+		assertNull(authorisationDTO.terms());
 	}
 
 	@Test
@@ -333,13 +340,13 @@ class ClerkTranslatorServiceTest {
 		ClerkTranslatorAuthorisationDTO kktAuthorisationDTO = authorisationDTOS.stream()
 				.filter(dto -> dto.basis().equals(AuthorisationBasis.KKT)).toList().get(0);
 
-		assertEquals(term1BeginDate, autAuthorisationDTO.term().beginDate());
-		assertEquals(term1EndDate, autAuthorisationDTO.term().endDate());
+		assertEquals(term1BeginDate, autAuthorisationDTO.terms().get(0).beginDate());
+		assertEquals(term1EndDate, autAuthorisationDTO.terms().get(0).endDate());
 		assertEquals("ru", autAuthorisationDTO.languagePairs().get(0).from());
 		assertEquals("fi", autAuthorisationDTO.languagePairs().get(0).to());
 
-		assertEquals(term2BeginDate, kktAuthorisationDTO.term().beginDate());
-		assertEquals(term2EndDate, kktAuthorisationDTO.term().endDate());
+		assertEquals(term2BeginDate, kktAuthorisationDTO.terms().get(0).beginDate());
+		assertEquals(term2EndDate, kktAuthorisationDTO.terms().get(0).endDate());
 		assertEquals("fi", kktAuthorisationDTO.languagePairs().get(0).from());
 		assertEquals("en", kktAuthorisationDTO.languagePairs().get(0).to());
 	}
@@ -380,8 +387,10 @@ class ClerkTranslatorServiceTest {
 
 		ClerkTranslatorAuthorisationDTO authorisationDTO = responseDTO.translators().get(0).authorisations().get(0);
 
-		assertEquals(term3BeginDate, authorisationDTO.term().beginDate());
-		assertEquals(term3EndDate, authorisationDTO.term().endDate());
+		assertEquals(1, authorisationDTO.terms().size());
+
+		assertEquals(term3BeginDate, authorisationDTO.terms().get(0).beginDate());
+		assertEquals(term3EndDate, authorisationDTO.terms().get(0).endDate());
 	}
 
 }


### PR DESCRIPTION
Tarkasteltavaksi pull request, jossa alustava toteutus (vaatii sekä refaktorointia että testejä) kääntäjän tarkastelusivulla tarvittavaa kääntäjän rajapintaa varten.

Pohdin, että tämä voisi palauttaa samaa dataa kuin listauskin eli tässä yhden `ClerkTranslatorDTO` modelin. Listauksessa ei kuitenkaan jatkossa palauteta todennäköisesti yhteystietoja kokonaisuudessaan (toisin kuin tässä) eikä siinä ole myöskään auktorisointeja kohti niin paljon tietoa, kuin mitä täältä tulee. Lisäsinkin uusia auktorisointikohtaisia nullable-kenttinä osaksi listauksessakin käytettyä `ClerkTranslatorAuthorisationDTO` modelia ja samanaikaisesti vaihdoin ko. modelissa kentän `term` tilalle `terms`, joka sisältää listan voimassaoloaikoja. Listausendpointissa tuon sisältö on tästä lähin 1 ja siinä palautetaan vain uusin voimassaoloaika kuten tähänkin asti kentässä `term` palautettiin.

Nyt lähinnä draft pull request tästä auki sillä ajatuksella, että voidaan pohtia yhdessä, halutaanko `get`-rajapinta toteuttaa tällä tavoin vai olisiko parempi, että käytettäisiin erillisiä modeleita siihen. Itse enempi tällä kannalla mutta molemmissa hyvät ja huonot puolensa.