### PR TITLE
OPHAKTKEH-179: language pair part of authorisation

### DIFF
--- a/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
@@ -24,24 +24,6 @@ import {
   selectFilteredSelectedIds,
 } from 'redux/selectors/clerkTranslator';
 import { Utils } from 'utils';
-import {
-  Authorisation,
-  effectiveAuthorisationTerm,
-} from 'interfaces/authorisation';
-
-const getAuthorisationData = (authorisation: Authorisation) => {
-  const { fromLang, toLang, basis, permissionToPublish } = authorisation;
-  const effectiveTerm = effectiveAuthorisationTerm(authorisation);
-
-  return {
-    fromLang,
-    toLang,
-    basis,
-    effectiveTermStart: effectiveTerm?.start,
-    effectiveTermEnd: effectiveTerm?.end,
-    permissionToPublish,
-  };
-};
 
 const getRowDetails = (
   translator: ClerkTranslator,
@@ -71,8 +53,7 @@ const ListingRow = ({
     keyPrefix: 'akt.component.clerkTranslatorListing',
   });
   const { firstName, lastName } = translator.contactDetails;
-  const authorisationDatas =
-    translator.authorisations.map(getAuthorisationData);
+  const authorisations = translator.authorisations;
   const translateLanguage = useKoodistoLanguagesTranslation();
 
   return (
@@ -89,37 +70,39 @@ const ListingRow = ({
       </TableCell>
       <TableCell>
         <div className="rows">
-          {authorisationDatas.map(({ fromLang, toLang }, idx) => (
+          {authorisations.map(({ langPair }, idx) => (
             <Text key={idx}>
-              {`${translateLanguage(fromLang)} - ${translateLanguage(toLang)}`}
+              {`${translateLanguage(langPair.from)} - ${translateLanguage(
+                langPair.to
+              )}`}
             </Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {authorisationDatas.map(({ basis }, idx) => (
+          {authorisations.map(({ basis }, idx) => (
             <Text key={idx}>{basis}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {authorisationDatas.map(({ effectiveTermStart }, idx) => (
-            <Text key={idx}>{Utils.formatDate(effectiveTermStart)}</Text>
+          {authorisations.map(({ effectiveTerm }, idx) => (
+            <Text key={idx}>{Utils.formatDate(effectiveTerm?.start)}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {authorisationDatas.map(({ effectiveTermEnd }, idx) => (
-            <Text key={idx}>{Utils.formatDate(effectiveTermEnd)}</Text>
+          {authorisations.map(({ effectiveTerm }, idx) => (
+            <Text key={idx}>{Utils.formatDate(effectiveTerm?.end)}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {authorisationDatas.map(({ permissionToPublish }, idx) => (
+          {authorisations.map(({ permissionToPublish }, idx) => (
             <Text key={idx}>
               {t(`permissionToPublish.${permissionToPublish}`)}
             </Text>

--- a/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
@@ -24,22 +24,23 @@ import {
   selectFilteredSelectedIds,
 } from 'redux/selectors/clerkTranslator';
 import { Utils } from 'utils';
-import { effectiveAuthorisationTerm } from 'interfaces/authorisation';
+import {
+  Authorisation,
+  effectiveAuthorisationTerm,
+} from 'interfaces/authorisation';
 
-const getLanguagePairsWithAuthorisations = (translator: ClerkTranslator) => {
-  return translator.authorisations.flatMap((authorisation) => {
-    const { basis, languagePairs } = authorisation;
-    const term = effectiveAuthorisationTerm(authorisation);
+const getAuthorisationData = (authorisation: Authorisation) => {
+  const { fromLang, toLang, basis, permissionToPublish } = authorisation;
+  const effectiveTerm = effectiveAuthorisationTerm(authorisation);
 
-    return languagePairs.map(({ from, to, permissionToPublish }) => ({
-      from,
-      to,
-      permissionToPublish,
-      authorisationBasis: basis,
-      authorisationStart: term?.start,
-      authorisationEnd: term?.end,
-    }));
-  });
+  return {
+    fromLang,
+    toLang,
+    basis,
+    effectiveTermStart: effectiveTerm?.start,
+    effectiveTermEnd: effectiveTerm?.end,
+    permissionToPublish,
+  };
 };
 
 const getRowDetails = (
@@ -70,8 +71,8 @@ const ListingRow = ({
     keyPrefix: 'akt.component.clerkTranslatorListing',
   });
   const { firstName, lastName } = translator.contactDetails;
-  const languagesWithAuthorisations =
-    getLanguagePairsWithAuthorisations(translator);
+  const authorisationDatas =
+    translator.authorisations.map(getAuthorisationData);
   const translateLanguage = useKoodistoLanguagesTranslation();
 
   return (
@@ -88,37 +89,37 @@ const ListingRow = ({
       </TableCell>
       <TableCell>
         <div className="rows">
-          {languagesWithAuthorisations.map(({ from, to }, idx) => (
+          {authorisationDatas.map(({ fromLang, toLang }, idx) => (
             <Text key={idx}>
-              {`${translateLanguage(from)} - ${translateLanguage(to)}`}
+              {`${translateLanguage(fromLang)} - ${translateLanguage(toLang)}`}
             </Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {languagesWithAuthorisations.map(({ authorisationBasis }, idx) => (
-            <Text key={idx}>{authorisationBasis}</Text>
+          {authorisationDatas.map(({ basis }, idx) => (
+            <Text key={idx}>{basis}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {languagesWithAuthorisations.map(({ authorisationStart }, idx) => (
-            <Text key={idx}>{Utils.formatDate(authorisationStart)}</Text>
+          {authorisationDatas.map(({ effectiveTermStart }, idx) => (
+            <Text key={idx}>{Utils.formatDate(effectiveTermStart)}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {languagesWithAuthorisations.map(({ authorisationEnd }, idx) => (
-            <Text key={idx}>{Utils.formatDate(authorisationEnd)}</Text>
+          {authorisationDatas.map(({ effectiveTermEnd }, idx) => (
+            <Text key={idx}>{Utils.formatDate(effectiveTermEnd)}</Text>
           ))}
         </div>
       </TableCell>
       <TableCell>
         <div className="rows">
-          {languagesWithAuthorisations.map(({ permissionToPublish }, idx) => (
+          {authorisationDatas.map(({ permissionToPublish }, idx) => (
             <Text key={idx}>
               {t(`permissionToPublish.${permissionToPublish}`)}
             </Text>

--- a/src/main/reactjs/src/interfaces/authorisation.ts
+++ b/src/main/reactjs/src/interfaces/authorisation.ts
@@ -1,5 +1,10 @@
 import { ClerkLanguagePair } from 'interfaces/language';
 
+export interface LanguagePair {
+  from: string;
+  to: string;
+}
+
 type AuthorisationBasis = 'AUT' | 'KKT' | 'VIR';
 
 export interface AuthorisationTerm {
@@ -7,14 +12,8 @@ export interface AuthorisationTerm {
   end?: Date;
 }
 
-export interface APIAuthorisationTerm {
-  beginDate: string;
-  endDate?: string;
-}
-
 export interface Authorisation {
-  fromLang: string;
-  toLang: string;
+  langPair: LanguagePair;
   basis: AuthorisationBasis;
   autDate: Date;
   kktCheck: string;
@@ -22,7 +21,13 @@ export interface Authorisation {
   assuranceDate: Date;
   meetingDate: Date;
   terms?: Array<AuthorisationTerm>;
+  effectiveTerm?: AuthorisationTerm;
   permissionToPublish: boolean;
+}
+
+export interface APIAuthorisationTerm {
+  beginDate: string;
+  endDate?: string;
 }
 
 export interface APIAuthorisation {
@@ -35,18 +40,3 @@ export interface APIAuthorisation {
   terms?: Array<APIAuthorisationTerm>;
   languagePairs: Array<ClerkLanguagePair>;
 }
-
-const termsComparator = (a: AuthorisationTerm, b: AuthorisationTerm) => {
-  return a.start > b.start ? -1 : 1;
-};
-
-export const effectiveAuthorisationTerm = (authorisation: Authorisation) => {
-  if (authorisation.terms && authorisation.terms.length > 0) {
-    const copiedTerms = [...authorisation.terms];
-    copiedTerms.sort(termsComparator);
-
-    return copiedTerms[0];
-  }
-
-  return null;
-};

--- a/src/main/reactjs/src/interfaces/authorisation.ts
+++ b/src/main/reactjs/src/interfaces/authorisation.ts
@@ -13,6 +13,8 @@ export interface APIAuthorisationTerm {
 }
 
 export interface Authorisation {
+  fromLang: string;
+  toLang: string;
   basis: AuthorisationBasis;
   autDate: Date;
   kktCheck: string;
@@ -20,7 +22,7 @@ export interface Authorisation {
   assuranceDate: Date;
   meetingDate: Date;
   terms?: Array<AuthorisationTerm>;
-  languagePairs: Array<ClerkLanguagePair>;
+  permissionToPublish: boolean;
 }
 
 export interface APIAuthorisation {

--- a/src/main/reactjs/src/redux/selectors/clerkTranslator.ts
+++ b/src/main/reactjs/src/redux/selectors/clerkTranslator.ts
@@ -2,10 +2,7 @@ import { createSelector } from 'reselect';
 
 import { RootState } from 'configs/redux';
 import { ClerkTranslator } from 'interfaces/clerkTranslator';
-import {
-  Authorisation,
-  effectiveAuthorisationTerm,
-} from 'interfaces/authorisation';
+import { Authorisation } from 'interfaces/authorisation';
 import { AuthorisationStatus } from 'enums/clerkTranslator';
 
 export const clerkTranslatorsSelector = (state: RootState) =>
@@ -58,7 +55,7 @@ export const selectFilteredSelectedIds = createSelector(
 // Helpers
 
 const isAuthorisationValid = (authorisation: Authorisation, now: Date) => {
-  const term = effectiveAuthorisationTerm(authorisation);
+  const term = authorisation.effectiveTerm;
   if (!term || !term.end) {
     return true;
   }
@@ -70,7 +67,7 @@ const isAuthorisationExpiringSoon = (
   authorisation: Authorisation,
   expiringSoonThreshold: Date
 ) => {
-  const term = effectiveAuthorisationTerm(authorisation);
+  const term = authorisation.effectiveTerm;
   if (!term || !term.end) {
     return false;
   }

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -11,11 +11,14 @@ export class APIUtils {
   ): Authorisation {
     return {
       ...authorisation,
+      fromLang: authorisation.languagePairs[0].from,
+      toLang: authorisation.languagePairs[0].to,
       autDate: new Date(authorisation.autDate),
       virDate: new Date(authorisation.virDate),
       assuranceDate: new Date(authorisation.assuranceDate),
       meetingDate: new Date(authorisation.meetingDate),
       terms: APIUtils.convertAPIAuthorisationTerms(authorisation.terms),
+      permissionToPublish: authorisation.languagePairs[0].permissionToPublish,
     };
   }
 

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -2,6 +2,8 @@ import {
   APIAuthorisation,
   APIAuthorisationTerm,
   Authorisation,
+  AuthorisationTerm,
+  LanguagePair,
 } from 'interfaces/authorisation';
 import { APIMeetingDate } from 'interfaces/meetingDate';
 
@@ -9,16 +11,35 @@ export class APIUtils {
   static convertAPIAuthorisation(
     authorisation: APIAuthorisation
   ): Authorisation {
+    const effectiveAuthorisationTerm = (terms?: Array<AuthorisationTerm>) => {
+      const comparator = (a: AuthorisationTerm, b: AuthorisationTerm) => {
+        return a.start > b.start ? -1 : 1;
+      };
+
+      if (terms && terms.length > 0) {
+        const copiedTerms = [...terms];
+        copiedTerms.sort(comparator);
+
+        return copiedTerms[0];
+      }
+    };
+
+    const [clerkLanguagePair] = authorisation.languagePairs;
+    const langPair: LanguagePair = { ...clerkLanguagePair };
+
+    const terms = APIUtils.convertAPIAuthorisationTerms(authorisation.terms);
+    const effectiveTerm = effectiveAuthorisationTerm(terms);
+
     return {
       ...authorisation,
-      fromLang: authorisation.languagePairs[0].from,
-      toLang: authorisation.languagePairs[0].to,
+      langPair,
       autDate: new Date(authorisation.autDate),
       virDate: new Date(authorisation.virDate),
       assuranceDate: new Date(authorisation.assuranceDate),
       meetingDate: new Date(authorisation.meetingDate),
-      terms: APIUtils.convertAPIAuthorisationTerms(authorisation.terms),
-      permissionToPublish: authorisation.languagePairs[0].permissionToPublish,
+      terms,
+      effectiveTerm,
+      permissionToPublish: clerkLanguagePair.permissionToPublish,
     };
   }
 


### PR DESCRIPTION
Julkiselle puolelle ei tarvinnut tehdä muutoksia, sillä `languagePairs` koko on suurempi kuin 1, mikäli käyttäjällä on useampi kuin 1 auktorisointi. Voidaan tosin muokata ko. rajapintaa noin muuten tiketissä OPHAKTKEH-180 kuvatulla tavalla tämän ja backend muutosten jälkeen jos halutaan.

Testasin tätä logiikkaa luomalla uudet auktorisoinnit ajamalla jo kertalleen initialisoituun kantaan 4-init.sql skriptistä rivit 48-85 (toisien auktorisointien luonnit kääntäjiä varten) ja lisäten kaikille auktorisoinneille kieliparin `SV - EN`

<img width="1230" alt="Screenshot 2022-01-14 at 11 37 16" src="https://user-images.githubusercontent.com/6399652/149494440-fd7dc9df-c321-403d-9ac3-e669421b183e.png">
.