### PR TITLE
OPHAKTKEH-159: recipient name added to emails

### DIFF
--- a/db/1_tables.sql
+++ b/db/1_tables.sql
@@ -229,14 +229,14 @@ CREATE TABLE public.email (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     modified_at timestamp with time zone DEFAULT now() NOT NULL,
     deleted_at timestamp with time zone,
-    sender text NOT NULL,
-    recipient text NOT NULL,
+    recipient_address text NOT NULL,
     subject text NOT NULL,
     body text NOT NULL,
     sent_at timestamp with time zone,
     error text,
     email_type character varying(255) NOT NULL,
-    ext_id text
+    ext_id text,
+    recipient_name text NOT NULL
 );
 
 
@@ -330,7 +330,7 @@ CREATE TABLE public.translator (
     identity_number character varying(255),
     first_name text NOT NULL,
     last_name text NOT NULL,
-    email text,
+    email character varying(255),
     phone_number text,
     street text,
     town text,
@@ -449,6 +449,14 @@ ALTER TABLE ONLY public.meeting_date
 
 ALTER TABLE ONLY public.shedlock
     ADD CONSTRAINT shedlock_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: translator translator_email_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.translator
+    ADD CONSTRAINT translator_email_key UNIQUE (email);
 
 
 --

--- a/db/3_liquibase.sql
+++ b/db/3_liquibase.sql
@@ -81,6 +81,8 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2022-01-07-add-person_details	terova	migrations.xml	2022-01-14 12:10:40.378113	18	EXECUTED	8:103587d2cafb92743989f5e1c05021fe	dropColumn tableName=translator; addColumn tableName=translator		\N	4.3.5	\N	\N	2155039865
 2022-01-14-move_language_pair_to_authorisation	terova	migrations.xml	2022-01-14 12:10:40.396453	19	EXECUTED	8:c6119c02b1bdfe30db84c0a58e3d3c50	addColumn tableName=authorisation; dropTable tableName=language_pair		\N	4.3.5	\N	\N	2155039865
 2022-01-20-add-column-authorisation_diary_number	mikhuttu	migrations.xml	2022-01-20 14:36:57.58396	20	EXECUTED	8:3e43e94da3d6257a9d6ab89a16c53183	addColumn tableName=authorisation		\N	4.3.5	\N	\N	2689417384
+2022-01-21-change_email_columns	mikhuttu	migrations.xml	2022-01-21 09:29:52.090978	21	EXECUTED	8:f5dbcf2cce10ccee99da3b4b1f60799f	dropColumn tableName=email; addColumn tableName=email; renameColumn newColumnName=recipient_address, oldColumnName=recipient, tableName=email		\N	4.3.5	\N	\N	2757391940
+2022-01-21-modify_translator_email	mikhuttu	migrations.xml	2022-01-21 09:29:52.156223	22	EXECUTED	8:4f224d2fe743d0f5bb6ccb68d77853aa	modifyDataType columnName=email, tableName=translator; addUniqueConstraint tableName=translator		\N	4.3.5	\N	\N	2757391940
 \.
 
 

--- a/src/main/java/fi/oph/akt/model/Email.java
+++ b/src/main/java/fi/oph/akt/model/Email.java
@@ -23,11 +23,15 @@ public class Email extends BaseEntity {
   @Column(name = "email_id", nullable = false)
   private long id;
 
-  @Column(name = "sender", nullable = false)
-  private String sender;
+  @Column(name = "email_type", nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private EmailType emailType;
 
-  @Column(name = "recipient", nullable = false)
-  private String recipient;
+  @Column(name = "recipient_name", nullable = false)
+  private String recipientName;
+
+  @Column(name = "recipient_address", nullable = false)
+  private String recipientAddress;
 
   @Column(name = "subject", nullable = false)
   private String subject;
@@ -40,10 +44,6 @@ public class Email extends BaseEntity {
 
   @Column(name = "error")
   private String error;
-
-  @Column(name = "email_type", nullable = false)
-  @Enumerated(value = EnumType.STRING)
-  private EmailType emailType;
 
   @Column(name = "ext_id")
   private String extId;

--- a/src/main/java/fi/oph/akt/model/Translator.java
+++ b/src/main/java/fi/oph/akt/model/Translator.java
@@ -39,7 +39,8 @@ public class Translator extends BaseEntity {
   @Column(name = "last_name", nullable = false)
   private String lastName;
 
-  @Column(name = "email")
+  @Size(min = 1, max = 255)
+  @Column(name = "email", unique = true)
   private String email;
 
   @Column(name = "phone_number")
@@ -56,4 +57,8 @@ public class Translator extends BaseEntity {
 
   @Column(name = "country")
   private String country;
+
+  public String getFullName() {
+    return firstName + " " + lastName;
+  }
 }

--- a/src/main/java/fi/oph/akt/service/email/EmailData.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailData.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.NonNull;
 
 public record EmailData(
-  @NonNull String sender,
-  @NonNull String recipient,
+  @NonNull String recipientName,
+  @NonNull String recipientAddress,
   @NonNull String subject,
   @NonNull String body
 ) {
@@ -18,8 +18,8 @@ public record EmailData(
   public static EmailData createFromEmail(final Email email) {
     return EmailData
       .builder()
-      .sender(email.getSender())
-      .recipient(email.getRecipient())
+      .recipientName(email.getRecipientName())
+      .recipientAddress(email.getRecipientAddress())
       .subject(email.getSubject())
       .body(email.getBody())
       .build();

--- a/src/main/java/fi/oph/akt/service/email/EmailService.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailService.java
@@ -28,8 +28,8 @@ public class EmailService {
   public Long saveEmail(final EmailType type, final EmailData emailData) {
     final Email email = new Email();
     email.setEmailType(type);
-    email.setSender(emailData.sender());
-    email.setRecipient(emailData.recipient());
+    email.setRecipientName(emailData.recipientName());
+    email.setRecipientAddress(emailData.recipientAddress());
     email.setSubject(emailData.subject());
     email.setBody(emailData.body());
 

--- a/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -479,4 +479,21 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="2022-01-21-change_email_columns" author="mikhuttu">
+        <dropColumn tableName="email">
+            <column name="sender"/>
+        </dropColumn>
+        <addColumn tableName="email">
+            <column name="recipient_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <renameColumn tableName="email" oldColumnName="recipient" newColumnName="recipient_address"/>
+    </changeSet>
+
+    <changeSet id="2022-01-21-modify_translator_email" author="mikhuttu">
+        <modifyDataType tableName="translator" columnName="email" newDataType="VARCHAR(255)"/>
+        <addUniqueConstraint tableName="translator" columnNames="email"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/fi/oph/akt/Factory.java
+++ b/src/test/java/fi/oph/akt/Factory.java
@@ -22,8 +22,8 @@ public class Factory {
 
   public static Translator translator() {
     final Translator translator = new Translator();
-    translator.setFirstName("foo");
-    translator.setLastName("bar");
+    translator.setFirstName("Foo");
+    translator.setLastName("Bar");
     return translator;
   }
 
@@ -54,9 +54,9 @@ public class Factory {
   public static Email email(final EmailType emailType) {
     final Email email = new Email();
     email.setEmailType(emailType);
-    email.setSender("Lasse Lähettäjä");
-    email.setRecipient("ville.vastaanottaja@invalid");
-    email.setSubject("Spostin otsikko");
+    email.setRecipientName("Ville Vastaanottaja");
+    email.setRecipientAddress("ville.vastaanottaja@invalid");
+    email.setSubject("Otsikko");
     email.setBody("Sisältö on tässä");
 
     return email;

--- a/src/test/java/fi/oph/akt/service/email/EmailServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/email/EmailServiceTest.java
@@ -51,8 +51,8 @@ class EmailServiceTest {
   public void saveEmailTest() {
     final EmailData emailData = EmailData
       .builder()
-      .sender("lähettäjä")
-      .recipient("vastaanottaja@invalid")
+      .recipientName("Vastaanottaja")
+      .recipientAddress("vastaanottaja@invalid")
       .subject("testiotsikko")
       .body("testiviesti")
       .build();
@@ -61,8 +61,8 @@ class EmailServiceTest {
     final Email email = emailRepository.getById(emailId);
 
     assertEquals(EmailType.CONTACT_REQUEST, email.getEmailType());
-    assertEquals("lähettäjä", email.getSender());
-    assertEquals("vastaanottaja@invalid", email.getRecipient());
+    assertEquals("Vastaanottaja", email.getRecipientName());
+    assertEquals("vastaanottaja@invalid", email.getRecipientAddress());
     assertEquals("testiotsikko", email.getSubject());
     assertEquals("testiviesti", email.getBody());
     assertNull(email.getSentAt());
@@ -87,8 +87,9 @@ class EmailServiceTest {
     assertNull(updatedEmail.getError());
 
     verify(emailSenderMock).sendEmail(emailDataCaptor.capture());
-    assertEquals(savedEmail.getSender(), emailDataCaptor.getValue().sender());
-    assertEquals(savedEmail.getRecipient(), emailDataCaptor.getValue().recipient());
+
+    assertEquals(savedEmail.getRecipientName(), emailDataCaptor.getValue().recipientName());
+    assertEquals(savedEmail.getRecipientAddress(), emailDataCaptor.getValue().recipientAddress());
     assertEquals(savedEmail.getSubject(), emailDataCaptor.getValue().subject());
     assertEquals(savedEmail.getBody(), emailDataCaptor.getValue().body());
   }

--- a/src/test/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalveluTest.java
+++ b/src/test/java/fi/oph/akt/service/email/sender/EmailSenderViestintapalveluTest.java
@@ -42,8 +42,8 @@ class EmailSenderViestintapalveluTest {
 
     final EmailData emailData = EmailData
       .builder()
-      .sender("lähettäjä")
-      .recipient("vastaanottaja@invalid")
+      .recipientName("vastaanottaja")
+      .recipientAddress("vastaanottaja@invalid")
       .subject("testiotsikko")
       .body("testiviesti")
       .build();
@@ -59,10 +59,12 @@ class EmailSenderViestintapalveluTest {
     assertThat(body).extractingJsonPathBooleanValue("$.email.html").isEqualTo(true);
     assertThat(body).extractingJsonPathStringValue("$.email.charset").isEqualTo("UTF-8");
     assertThat(body).extractingJsonPathStringValue("$.email.callingProcess").isEqualTo("akt");
-    assertThat(body).extractingJsonPathStringValue("$.email.sender").isEqualTo("lähettäjä");
+    assertThat(body).extractingJsonPathStringValue("$.email.sender").isEqualTo("AKT");
     assertThat(body).extractingJsonPathStringValue("$.email.subject").isEqualTo("testiotsikko");
     assertThat(body).extractingJsonPathStringValue("$.email.body").isEqualTo("testiviesti");
+
     assertThat(body).extractingJsonPathArrayValue("$.recipient").size().isEqualTo(1);
+    assertThat(body).extractingJsonPathStringValue("$.recipient[0].name").isEqualTo("vastaanottaja");
     assertThat(body).extractingJsonPathStringValue("$.recipient[0].email").isEqualTo("vastaanottaja@invalid");
   }
 }


### PR DESCRIPTION
Vastaanottajan nimi lisätty email-tauluun ja samalla poistettu `sender` kenttä, joka oli kaikille sähköposteille "AKT" enkä nähnyt ainakaan suoralta kädeltä syytä, miksi tuo jatkossa olisi erilainen eri maileja kohti. Lisäsin myös emailin uniikiksi kentäksi kääntäjille, vaikka loppujen lopuksi ko. muutos ei ollutkaan koodin tasolla tarpeellinen.

Toistaiseksi testaamatta, että muutos toimii ryhmäsähköpostipalvelua vasten, mutta OTR:n koodin perusteella vaikuttaisi olevan ok.