### PR TITLE
OPHAKTKEH-213: Lisätiedot sisältö init-skriptiin

### DIFF
--- a/db/1_tables.sql
+++ b/db/1_tables.sql
@@ -44,7 +44,8 @@ CREATE TABLE public.authorisation (
     to_lang character varying(10) NOT NULL,
     permission_to_publish boolean NOT NULL,
     diary_number character varying(255) NOT NULL,
-    CONSTRAINT ck_authorisation_by_basis CHECK (((((basis)::text = 'AUT'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NOT NULL) AND (kkt_check IS NULL) AND (vir_date IS NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'KKT'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NULL) AND (kkt_check IS NOT NULL) AND (vir_date IS NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'VIR'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NULL) AND (kkt_check IS NULL) AND (vir_date IS NOT NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'VIR'::text) AND (meeting_date_id IS NULL) AND (aut_date IS NULL) AND (kkt_check IS NULL) AND (vir_date IS NOT NULL) AND (assurance_date IS NULL))))
+    CONSTRAINT ck_authorisation_by_basis CHECK (((((basis)::text = 'AUT'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NOT NULL) AND (kkt_check IS NULL) AND (vir_date IS NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'KKT'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NULL) AND (kkt_check IS NOT NULL) AND (vir_date IS NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'VIR'::text) AND (meeting_date_id IS NOT NULL) AND (aut_date IS NULL) AND (kkt_check IS NULL) AND (vir_date IS NOT NULL) AND (assurance_date IS NOT NULL)) OR (((basis)::text = 'VIR'::text) AND (meeting_date_id IS NULL) AND (aut_date IS NULL) AND (kkt_check IS NULL) AND (vir_date IS NOT NULL) AND (assurance_date IS NULL)))),
+    CONSTRAINT ck_authorisation_from_to CHECK ((((from_lang)::text <> (to_lang)::text) AND (((from_lang)::text = ANY ((ARRAY['FI'::character varying, 'SV'::character varying, 'SEIN'::character varying, 'SEKO'::character varying, 'SEPO'::character varying])::text[])) OR ((to_lang)::text = ANY ((ARRAY['FI'::character varying, 'SV'::character varying, 'SEIN'::character varying, 'SEKO'::character varying, 'SEPO'::character varying])::text[])))))
 );
 
 
@@ -337,7 +338,8 @@ CREATE TABLE public.translator (
     street text,
     town text,
     postal_code text,
-    country text
+    country text,
+    extra_information text
 );
 
 

--- a/db/3_liquibase.sql
+++ b/db/3_liquibase.sql
@@ -87,6 +87,8 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2022-01-21-modify_translator_email	mikhuttu	migrations.xml	2022-01-21 09:29:52.156223	22	EXECUTED	8:4f224d2fe743d0f5bb6ccb68d77853aa	modifyDataType columnName=email, tableName=translator; addUniqueConstraint tableName=translator		\N	4.3.5	\N	\N	2757391940
 2022-02-01-new_contact_request_email_types	mikhuttu	migrations.xml	2022-02-01 08:51:57.257592	23	EXECUTED	8:3e31435286a431bdec520a7b01a537ab	insert tableName=email_type; insert tableName=email_type		\N	4.3.5	\N	\N	3705517103
 2022-02-01-rename_email_type_contact_request	mikhuttu	migrations.xml	2022-02-01 08:51:57.274921	24	EXECUTED	8:636e63499d0a369945bd90269688102d	insert tableName=email_type; update tableName=email; delete tableName=email_type		\N	4.3.5	\N	\N	3705517103
+2022-02-08-check_from_lang_and_to_lang	terova	migrations.xml	2022-02-09 15:53:47.664419	25	EXECUTED	8:b4c7cad76249520a682116e1b3e936ae	sql		\N	4.3.5	\N	\N	4422027486
+2022-02-09-add-column-translator_extra_information	mikhuttu	migrations.xml	2022-02-09 15:53:47.676833	26	EXECUTED	8:529f01eadf925629f9f9f5a85f25dadc	addColumn tableName=translator		\N	4.3.5	\N	\N	4422027486
 \.
 
 

--- a/db/4_init.sql
+++ b/db/4_init.sql
@@ -17,7 +17,7 @@ VALUES ('2022-11-01');
 INSERT INTO meeting_date(date)
 VALUES ('2025-01-01');
 
-INSERT INTO translator(identity_number, first_name, last_name, email, phone_number, street, town, postal_code, country)
+INSERT INTO translator(identity_number, first_name, last_name, email, phone_number, street, town, postal_code, country, extra_information)
 SELECT 'id' || i::text,
        first_names[mod(i, array_length(first_names, 1)) + 1],
        last_names[mod(i, array_length(last_names, 1)) + 1],
@@ -32,7 +32,8 @@ SELECT 'id' || i::text,
        postal_code[mod(i, array_length(postal_code, 1)) + 1],
        CASE mod(i, 7)
            WHEN 0 THEN 'Latvia'
-           ELSE country[mod(i, array_length(country, 1)) + 1] END
+           ELSE country[mod(i, array_length(country, 1)) + 1] END,
+       extra_information[mod(i, array_length(extra_information, 1)) + 1]
 FROM generate_series(1, 4900) AS i,
      (SELECT ('{Antti, Eero, Ilkka, Jari, Juha, Matti, Pekka, Timo, Iiro, Jukka, Kalle, ' ||
               'Kari, Marko, Mikko, Tapani, Ville, Anneli, Ella, Hanna, Iiris, Liisa, ' ||
@@ -51,7 +52,12 @@ FROM generate_series(1, 4900) AS i,
               'Kotka}')::text[] AS town) AS town_table,
      (SELECT ('{00100, 01200, 06100, 13500, 31600, 48600, ' ||
               '54460}')::text[] AS postal_code) AS postal_code_table,
-     (SELECT ('{Suomi, suomi, SUOMI, Finland, NULL}')::text[] AS country) AS country_table;
+     (SELECT ('{Suomi, suomi, SUOMI, Finland, NULL}')::text[] AS country) AS country_table,
+     (SELECT ('{Osoitetiedot päivitetty 1.1.1970., ' ||
+              'Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo., ' ||
+              'Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen, ' ||
+              'Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa., ' ||
+              'NULL}')::text[] AS extra_information) AS extra_information_table;
 
 -- insert authorisations for translators, for some we add multiple authorisations
 WITH translator_ids AS (
@@ -133,13 +139,13 @@ SELECT translator_id,
            WHEN mod(i, 17) = 0 THEN NULL
            ELSE now() END,
        from_langs[mod(i, array_length(from_langs, 1)) + 1],
-       langs[mod(i, array_length(langs, 1)) + 1],
+       to_langs[mod(i, array_length(to_langs, 1)) + 1],
        mod(i, 21) <> 0,
        -- temporary diary_number entries
        md5(random()::text)
 FROM translator_ids,
      (SELECT ('{FI, SEIN, SEKO, SEPO}')::text[] AS from_langs) AS from_langs_table,
-     (SELECT ('{BN, CA, CS, DA, DE, EL, EN, ET, FJ, FO, FR, GA, HE, HR, HU, JA, RU, SV, TT, TY, UG, UK, VI}')::text[] AS langs) AS langs_table
+     (SELECT ('{BN, CA, CS, DA, DE, EL, EN, ET, FJ, FO, FR, GA, HE, HR, HU, JA, RU, SV, TT, TY, UG, UK, VI}')::text[] AS to_langs) AS to_langs_table
 ;
 
 -- add inverse language pairs


### PR DESCRIPTION
Lisätiedot-kenttään lisätty jotakin suurin piirtein järkevää sisältöä init-skriptiin populoitaviksi osalle kääntäjistä. En saanut suoralta kädeltä escapetettua (`E` tekstin edessä?) pilkkuja enkä rivinvaihtoja, ne olisivat voineet olla testidatassa myös mielekkäitä.