### PR TITLE
Small improvements

### DIFF
--- a/src/main/reactjs/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
+++ b/src/main/reactjs/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
@@ -72,7 +72,7 @@ export const PublicTranslatorListingRow = ({
   const renderPhoneTableCells = () => (
     <TableCell>
       <div className="rows gapped">
-        <H2>{`${firstName} ${lastName}`}</H2>
+        <H2>{`${lastName}, ${firstName}`}</H2>
         <div className="columns gapped space-between">
           <div className="rows">
             <H3>{t('pages.translator.languagePairs')}</H3>
@@ -108,7 +108,7 @@ export const PublicTranslatorListingRow = ({
         />
       </TableCell>
       <TableCell>
-        <Text>{`${firstName} ${lastName}`}</Text>
+        <Text>{`${lastName}, ${firstName}`}</Text>
       </TableCell>
       <TableCell>
         {languagePairs.map(({ from, to }, k) => (

--- a/src/main/reactjs/src/configs/i18n.ts
+++ b/src/main/reactjs/src/configs/i18n.ts
@@ -19,13 +19,9 @@ const langFI = 'fi-FI';
 const langSV = 'sv-SE';
 const langEN = 'en-GB';
 
-const detectionOptions = {
-  order: ['localStorage', 'htmlTag'],
-  caches: ['localStorage'],
-};
+export type AppLanguages = typeof langFI | typeof langSV | typeof langEN;
 
-const supportedLangs = [langFI, langSV, langEN];
-export type supportedLanguages = typeof langFI | typeof langSV | typeof langEN;
+export const supportedLangs = [langFI, langSV, langEN];
 
 const resources = {
   [langFI]: {
@@ -40,6 +36,11 @@ const resources = {
     [I18nNamespace.Translation]: transEN,
     [I18nNamespace.KoodistoLanguages]: koodistoLangsEN,
   },
+};
+
+const detectionOptions = {
+  order: ['localStorage', 'htmlTag'],
+  caches: ['localStorage'],
 };
 
 // TypeScript definitions for react-i18next. IDE might show this to be unused, but ts does some type checking with it.

--- a/src/main/reactjs/src/utils/date.ts
+++ b/src/main/reactjs/src/utils/date.ts
@@ -1,9 +1,13 @@
 import { getCurrentLang, supportedLanguages } from 'configs/i18n';
 
-const dateFormattersByLocale = {
-  'fi-FI': new Intl.DateTimeFormat('fi-FI'),
-  'sv-SE': new Intl.DateTimeFormat('sv-SE'),
-  'en-GB': new Intl.DateTimeFormat('en-GB'),
+const dateFormatterByLocale = (locale: string) => {
+  const supportedLocales = ['fi-FI', 'sv-SE', 'en-GB'];
+
+  if (supportedLocales.indexOf(locale) >= 0) {
+    return new Intl.DateTimeFormat(locale);
+  }
+
+  return new Intl.DateTimeFormat('fi-FI');
 };
 
 export class DateUtils {
@@ -13,7 +17,7 @@ export class DateUtils {
     }
 
     const currentLang = getCurrentLang() as supportedLanguages;
-    const dateFormatter = dateFormattersByLocale[currentLang];
+    const dateFormatter = dateFormatterByLocale(currentLang);
 
     return dateFormatter.format(date);
   }

--- a/src/main/reactjs/src/utils/date.ts
+++ b/src/main/reactjs/src/utils/date.ts
@@ -1,13 +1,11 @@
-import { getCurrentLang, supportedLanguages } from 'configs/i18n';
+import { AppLanguages, getCurrentLang, supportedLangs } from 'configs/i18n';
 
-const dateFormatterByLocale = (locale: string) => {
-  const supportedLocales = ['fi-FI', 'sv-SE', 'en-GB'];
+const getDateTimeFormatter = (lang: AppLanguages) => {
+  const locale = supportedLangs.includes(lang.toString())
+    ? lang.toString()
+    : 'fi-FI';
 
-  if (supportedLocales.indexOf(locale) >= 0) {
-    return new Intl.DateTimeFormat(locale);
-  }
-
-  return new Intl.DateTimeFormat('fi-FI');
+  return new Intl.DateTimeFormat(locale);
 };
 
 export class DateUtils {
@@ -16,10 +14,10 @@ export class DateUtils {
       return '-';
     }
 
-    const currentLang = getCurrentLang() as supportedLanguages;
-    const dateFormatter = dateFormatterByLocale(currentLang);
+    const lang = getCurrentLang() as AppLanguages;
+    const dateTimeFormatter = getDateTimeFormatter(lang);
 
-    return dateFormatter.format(date);
+    return dateTimeFormatter.format(date);
   }
 
   static optionalStringToDate(dateString?: string) {


### PR DESCRIPTION
Havaitsin, että en saanut untuvalla Chromella virkailijasivua auki tai sivun lataus kaatui virheeseen, kun taas sama buildi toimi pallerolla Chromella täysin oikein. Lopulta huomasin, että untuvan virkailijakäyttöliittymässä käytettyä kielivalintaa ei ollukaan tehty ja valitun kielen sijaan headerin maapallo-ikonin vieressä ei ollut tekstiä lainkaan ja sain tämän ongelman korjattua valitsemalla kielen nopeasti ennen kuin sivun lataus ehti yhtään pidemmälle. En tiedä suoraan mistä tuo johtui / sen replikointi voi olla monimutkaista, mutta tämä korjaus nyt ainakin mahdollistaa sivun latautumisen tällaisen tilanteen sattuessa pakottaen datetimeformatterin käyttämään `fi-FI` default kielenä. Tämän juurisyytä voisi toki olla hyvä tutkia enempikin.