### PR TITLE
Commas removed from translator names from public and clerk searches

### DIFF
--- a/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/ClerkTranslatorListing.tsx
@@ -85,7 +85,7 @@ const ListingRow = ({
         <Checkbox checked={selected} color={Color.Secondary} />
       </TableCell>
       <TableCell>
-        <Text>{`${lastName}, ${firstName}`}</Text>
+        <Text>{`${lastName} ${firstName}`}</Text>
       </TableCell>
       <TableCell>
         <div className="rows">

--- a/src/main/reactjs/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
+++ b/src/main/reactjs/src/components/publicTranslator/listing/PublicTranslatorListingRow.tsx
@@ -72,7 +72,7 @@ export const PublicTranslatorListingRow = ({
   const renderPhoneTableCells = () => (
     <TableCell>
       <div className="rows gapped">
-        <H2>{`${lastName}, ${firstName}`}</H2>
+        <H2>{`${lastName} ${firstName}`}</H2>
         <div className="columns gapped space-between">
           <div className="rows">
             <H3>{t('pages.translator.languagePairs')}</H3>
@@ -108,7 +108,7 @@ export const PublicTranslatorListingRow = ({
         />
       </TableCell>
       <TableCell>
-        <Text>{`${lastName}, ${firstName}`}</Text>
+        <Text>{`${lastName} ${firstName}`}</Text>
       </TableCell>
       <TableCell>
         {languagePairs.map(({ from, to }, k) => (


### PR DESCRIPTION
Niklaksen kanssa sovittu muutos, että poistetaan pilkkuerotin sukunimen ja etunimen väliltä niin julkisesta kuin virkailijapuolen hauistakin.

```
[Mika Huttunen]
Voi ne kaikki molemmista poistaa ja formaatin pitää just kummassakin “Sukunimi Etunimi” muodossa?

[Niklas Isaksson]
Joo. Eli pilkku pois ja “Sukunimi Etunimi” järjestys ok. Tuo on hyvä järjestys myös julkisessa, koska varmaan useasti haetaan sukunimellä
```