### PR TITLE
OPHAKTKEH-243: removed messages from errors

### DIFF
--- a/src/main/java/fi/oph/akt/config/ControllerExceptionAdvice.java
+++ b/src/main/java/fi/oph/akt/config/ControllerExceptionAdvice.java
@@ -21,35 +21,42 @@ public class ControllerExceptionAdvice {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Object> handleMethodArgumentNotValidException(final MethodArgumentNotValidException ex) {
     LOG.error("MethodArgumentNotValidException: " + ex.getMessage());
-
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    return badRequest();
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Object> handleIllegalArgumentException(final IllegalArgumentException ex) {
     LOG.error("IllegalArgumentException: " + ex.getMessage());
-
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    return badRequest();
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<Object> handleHttpMessageNotReadableException(final HttpMessageNotReadableException ex) {
     LOG.error("HttpMessageNotReadableException: " + ex.getMessage());
-
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    return badRequest();
   }
 
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity<Object> handleNotFoundException(final NotFoundException ex) {
     LOG.error("NotFoundException: " + ex.getMessage());
-
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    return notFound();
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<Object> handleAll(final Exception ex) {
+  public ResponseEntity<Object> handleRest(final Exception ex) {
     LOG.error("Exception caught", ex);
+    return internalServerError();
+  }
 
-    return new ResponseEntity<>("exception: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  private ResponseEntity<Object> badRequest() {
+    return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+  }
+
+  private ResponseEntity<Object> notFound() {
+    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+  }
+
+  private ResponseEntity<Object> internalServerError() {
+    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/main/java/fi/oph/akt/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/fi/oph/akt/config/CustomAccessDeniedHandler.java
@@ -11,14 +11,11 @@ public class CustomAccessDeniedHandler {
   private static final Logger LOG = LoggerFactory.getLogger(CustomAccessDeniedHandler.class);
 
   public static AccessDeniedHandler create() {
-    return (request, response, e) -> {
-      LOG.error("AccessDeniedHandler", e);
+    return (request, response, ex) -> {
+      LOG.error("AccessDeniedHandler", ex);
       if (!response.isCommitted()) {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().print("{\"status\": \"FORBIDDEN\"}");
-        response.getWriter().flush();
-        response.getWriter().close();
       }
     };
   }


### PR DESCRIPTION
Poistettu palvelimen virhetilanteissa palauttamat informatiiviset virheviestit. Forbiddenin yhteydessä tulee tosin edelleen viesti muotoa
```
{
    "timestamp": "2022-02-24T15:06:50.367+00:00",
    "status": 403,
    "error": "Forbidden",
    "message": "Forbidden",
    "path": "/akt/api/v1/translator/contact-request"
}
```
tekiessä esim. yhteydenottopyynnön postmanilla ilman csrf-tokenia. En nyt suoralta kädeltä havainnut, miten tuon saisi pois jos sellaiseen mitään tarvettakaan.