### PR TITLE
OPHAKTKEH-242: former VIR filter

### DIFF
--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -113,7 +113,7 @@
           "authorised": "Auktorisoidut",
           "expiring": "Umpeutuvat",
           "expired": "Umpeutuneet",
-          "notAuthorised": "Ei auktorisoidut"
+          "formerVIR": "Ent. VIR"
         },
         "languagePair": {
           "title": "Haku kielittäin",

--- a/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorToggleFilters.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorToggleFilters.tsx
@@ -10,7 +10,7 @@ import {
 } from 'redux/selectors/clerkTranslator';
 
 export const ClerkTranslatorToggleFilters = () => {
-  const { authorised, expiring, expired } = useAppSelector(
+  const { authorised, expiring, expired, formerVIR } = useAppSelector(
     selectTranslatorsByAuthorisationStatus
   );
   const { t } = useAppTranslation({
@@ -31,6 +31,7 @@ export const ClerkTranslatorToggleFilters = () => {
     { status: AuthorisationStatus.Authorised, count: authorised.length },
     { status: AuthorisationStatus.Expiring, count: expiring.length },
     { status: AuthorisationStatus.Expired, count: expired.length },
+    { status: AuthorisationStatus.FormerVIR, count: formerVIR.length },
   ];
 
   return (

--- a/src/main/reactjs/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/listing/ClerkTranslatorListing.tsx
@@ -122,7 +122,7 @@ const ListingRow = ({ translator }: { translator: ClerkTranslator }) => {
         <div className="rows">
           {authorisations.map((a, idx) => (
             <Text key={idx}>
-              {AuthorisationUtils.isAuthorisationValid(a, currentDate)
+              {AuthorisationUtils.isAuthorisationEffective(a, currentDate)
                 ? translateCommon('yes')
                 : translateCommon('no')}
             </Text>

--- a/src/main/reactjs/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/AuthorisationDetails.tsx
@@ -89,7 +89,7 @@ export const AuthorisationDetails = () => {
               </TableCell>
               <TableCell>
                 <Text>
-                  {AuthorisationUtils.isAuthorisationValid(a, currentDate)
+                  {AuthorisationUtils.isAuthorisationEffective(a, currentDate)
                     ? translateCommon('yes')
                     : translateCommon('no')}
                 </Text>

--- a/src/main/reactjs/src/enums/clerkTranslator.ts
+++ b/src/main/reactjs/src/enums/clerkTranslator.ts
@@ -5,4 +5,5 @@ export enum AuthorisationStatus {
   Authorised = 'authorised',
   Expiring = 'expiring',
   Expired = 'expired',
+  FormerVIR = 'formerVIR',
 }

--- a/src/main/reactjs/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
+++ b/src/main/reactjs/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
@@ -19,6 +19,7 @@ const translatorCountsByAuthorisationStatus = {
   [AuthorisationStatus.Authorised]: 98,
   [AuthorisationStatus.Expiring]: 88,
   [AuthorisationStatus.Expired]: 2,
+  [AuthorisationStatus.FormerVIR]: 8,
 };
 
 describe('ClerkHomePage', () => {
@@ -42,6 +43,11 @@ describe('ClerkHomePage', () => {
       translatorCountsByAuthorisationStatus[AuthorisationStatus.Expired]
     );
 
+    onClerkHomePage.filterByAuthorisationStatus(AuthorisationStatus.FormerVIR);
+    onClerkHomePage.expectSelectedTranslatorsCount(
+      translatorCountsByAuthorisationStatus[AuthorisationStatus.FormerVIR]
+    );
+
     onClerkHomePage.filterByAuthorisationStatus(AuthorisationStatus.Authorised);
     onClerkHomePage.expectSelectedTranslatorsCount(
       translatorCountsByAuthorisationStatus[AuthorisationStatus.Authorised]
@@ -55,7 +61,7 @@ describe('ClerkHomePage', () => {
 
   it('should filter translators by to lang', () => {
     onClerkHomePage.filterByToLang('iiri');
-    onClerkHomePage.expectSelectedTranslatorsCount(7);
+    onClerkHomePage.expectSelectedTranslatorsCount(6); // 6 authorised, 1 former VIR
   });
 
   it('should filter translators by name', () => {
@@ -65,7 +71,7 @@ describe('ClerkHomePage', () => {
 
   it('should filter translators by authorisation basis', () => {
     onClerkHomePage.filterByAuthorisationBasis('VIR');
-    onClerkHomePage.expectSelectedTranslatorsCount(15);
+    onClerkHomePage.expectSelectedTranslatorsCount(7);
 
     // Authorisation with basis VIR should never expire => expect 0 matching translators.
     onClerkHomePage.filterByAuthorisationStatus(AuthorisationStatus.Expiring);

--- a/src/main/reactjs/src/utils/authorisation.ts
+++ b/src/main/reactjs/src/utils/authorisation.ts
@@ -2,14 +2,46 @@ import { Authorisation } from 'interfaces/authorisation';
 import { DateUtils } from 'utils/date';
 
 export class AuthorisationUtils {
-  static isAuthorisationValid(
+  static isAuthorisationEffective(
     { effectiveTerm }: Authorisation,
     currentDate: Date
   ) {
-    if (!effectiveTerm || !effectiveTerm.end) {
+    if (effectiveTerm && effectiveTerm.end) {
+      return DateUtils.isDatePartBeforeOrEqual(currentDate, effectiveTerm.end);
+    } else if (effectiveTerm) {
       return true;
+    } else {
+      return false;
+    }
+  }
+
+  static isAuthorisationExpiring = (
+    { effectiveTerm }: Authorisation,
+    currentDate: Date,
+    expiringThreshold: Date
+  ) => {
+    if (effectiveTerm && effectiveTerm.end) {
+      return (
+        DateUtils.isDatePartBeforeOrEqual(currentDate, effectiveTerm.end) &&
+        DateUtils.isDatePartBeforeOrEqual(effectiveTerm.end, expiringThreshold)
+      );
     }
 
-    return DateUtils.isDatePartBeforeOrEqual(currentDate, effectiveTerm.end);
+    return false;
+  };
+
+  static isAuthorisationExpired(
+    { effectiveTerm }: Authorisation,
+    currentDate: Date
+  ) {
+    if (effectiveTerm && effectiveTerm.end) {
+      return !DateUtils.isDatePartBeforeOrEqual(currentDate, effectiveTerm.end);
+    }
+
+    return false;
+  }
+
+  static isAuthorisationForFormerVIR({ effectiveTerm }: Authorisation) {
+    return !effectiveTerm;
   }
 }


### PR DESCRIPTION
ENT. VIR auktorisointistatusperusteinen filtteri lisätty virkailijan listausnäkymään. Samalla nimellä oleva filtteri olisi ehkä loogista lisätä myös auktorisointien tarkastelu- ja muokkausnäkymään kääntäjän sivulle sen sijaan, että entisten virallisten kääntäjien auktorisoinnit löytyisivät sieltä umpeutuneiden listan alta.