### PR TITLE
Virkailijapuolen kääntäjälistauksen nimisuodatusta koskevan testin korjaus

### DIFF
--- a/src/main/reactjs/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
+++ b/src/main/reactjs/src/tests/cypress/integration/clerk/clerk_translator.spec.ts
@@ -73,6 +73,11 @@ describe('ClerkHomePage', () => {
     onClerkHomePage.filterByToLang('iiri');
     onClerkHomePage.expectSelectedTranslatorsCount(1);
 
+    // First apply filter that doesn't match any name and expect zero results
+    onClerkHomePage.filterByName('Kari Kink');
+    onClerkHomePage.expectSelectedTranslatorsCount(0);
+
+    // Fix typo made above, check that results are as expected
     onClerkHomePage.filterByName('Kari Kin');
     onClerkHomePage.expectSelectedTranslatorsCount(1);
   });

--- a/src/main/reactjs/src/tests/cypress/support/page-objects/clerkHomePage.ts
+++ b/src/main/reactjs/src/tests/cypress/support/page-objects/clerkHomePage.ts
@@ -64,7 +64,10 @@ class ClerkHomePage {
   }
 
   filterByName(name: string) {
-    this.elements.nameField().type(name);
+    this.elements.nameField().clear();
+    this.elements.nameField().type(name + '{enter}');
+    // Ensure debounced name filter gets applied by waiting for more than 300ms
+    cy.tick(400);
   }
 
   sendEmail() {


### PR DESCRIPTION
As the useFixedDate(..) hook provides a static value for `cy.clock(..)`, use `cy.tick(..)` to advance clock so that debounced filter gets applied.