### PR TITLE
OPHAKTKEH-265: kääntäjän vakuutus

### DIFF
--- a/db/1_tables.sql
+++ b/db/1_tables.sql
@@ -303,7 +303,8 @@ CREATE TABLE public.translator (
     town text,
     postal_code text,
     country text,
-    extra_information text
+    extra_information text,
+    is_assured boolean NOT NULL
 );
 
 

--- a/db/1_tables.sql
+++ b/db/1_tables.sql
@@ -304,7 +304,7 @@ CREATE TABLE public.translator (
     postal_code text,
     country text,
     extra_information text,
-    is_assured boolean NOT NULL
+    is_assurance_given boolean NOT NULL
 );
 
 

--- a/db/3_liquibase.sql
+++ b/db/3_liquibase.sql
@@ -92,6 +92,7 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2022-02-28-move_authorisation_term_contents_under_authorisation	mikhuttu	migrations.xml	2022-02-28 10:33:22.318797	27	EXECUTED	8:aa2182fccae1c40bc76f6e82cc068187	dropForeignKeyConstraint baseTableName=authorisation_term, constraintName=fk_authorisation_term_authorisation; dropForeignKeyConstraint baseTableName=authorisation_term_reminder, constraintName=fk_authorisation_term_reminder_authorisation_term; de...		\N	4.3.5	\N	\N	6044401975
 2022-03-03-drop_authorisation_unused_date_columns	mikhuttu	migrations.xml	2022-03-03 13:29:48.667704	28	EXECUTED	8:772ddd0214963788b04ff8a118db6c37	sql; sql; dropColumn columnName=kkt_check, tableName=authorisation; dropColumn columnName=vir_date, tableName=authorisation; dropColumn columnName=assurance_date, tableName=authorisation		\N	4.3.5	\N	\N	6314188424
 2022-03-03-nullable_authorisation_diary_number	mikhuttu	migrations.xml	2022-03-03 13:29:48.68439	29	EXECUTED	8:4b9a27fa6f1252767f46578d7ae94f32	dropColumn columnName=diary_number, tableName=authorisation; addColumn tableName=authorisation		\N	4.3.5	\N	\N	6314188424
+2022-03-04-add_translator_has_assurance	mikhuttu	migrations.xml	2022-03-03 14:36:02.923327	30	EXECUTED	8:caed743700d7bdfaaae6d250b9ebdbe7	addColumn tableName=translator; dropDefaultValue columnName=is_assured, tableName=translator		\N	4.3.5	\N	\N	6318162732
 \.
 
 

--- a/db/3_liquibase.sql
+++ b/db/3_liquibase.sql
@@ -92,7 +92,7 @@ COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted
 2022-02-28-move_authorisation_term_contents_under_authorisation	mikhuttu	migrations.xml	2022-02-28 10:33:22.318797	27	EXECUTED	8:aa2182fccae1c40bc76f6e82cc068187	dropForeignKeyConstraint baseTableName=authorisation_term, constraintName=fk_authorisation_term_authorisation; dropForeignKeyConstraint baseTableName=authorisation_term_reminder, constraintName=fk_authorisation_term_reminder_authorisation_term; de...		\N	4.3.5	\N	\N	6044401975
 2022-03-03-drop_authorisation_unused_date_columns	mikhuttu	migrations.xml	2022-03-03 13:29:48.667704	28	EXECUTED	8:772ddd0214963788b04ff8a118db6c37	sql; sql; dropColumn columnName=kkt_check, tableName=authorisation; dropColumn columnName=vir_date, tableName=authorisation; dropColumn columnName=assurance_date, tableName=authorisation		\N	4.3.5	\N	\N	6314188424
 2022-03-03-nullable_authorisation_diary_number	mikhuttu	migrations.xml	2022-03-03 13:29:48.68439	29	EXECUTED	8:4b9a27fa6f1252767f46578d7ae94f32	dropColumn columnName=diary_number, tableName=authorisation; addColumn tableName=authorisation		\N	4.3.5	\N	\N	6314188424
-2022-03-04-add_translator_has_assurance	mikhuttu	migrations.xml	2022-03-03 14:36:02.923327	30	EXECUTED	8:caed743700d7bdfaaae6d250b9ebdbe7	addColumn tableName=translator; dropDefaultValue columnName=is_assured, tableName=translator		\N	4.3.5	\N	\N	6318162732
+2022-03-04-add_translator_is_assurance_given	mikhuttu	migrations.xml	2022-03-09 07:50:59.720426	30	EXECUTED	8:9a36f41e82b79a4eadcbc5632c78de37	addColumn tableName=translator; dropDefaultValue columnName=is_assurance_given, tableName=translator		\N	4.3.5	\N	\N	6812259593
 \.
 
 

--- a/db/4_init.sql
+++ b/db/4_init.sql
@@ -17,7 +17,8 @@ VALUES ('2022-11-01');
 INSERT INTO meeting_date(date)
 VALUES ('2025-01-01');
 
-INSERT INTO translator(identity_number, first_name, last_name, email, phone_number, street, town, postal_code, country, extra_information)
+INSERT INTO translator(identity_number, first_name, last_name, email, phone_number, street, town, postal_code, country,
+                       extra_information, is_assured)
 SELECT 'id' || i::text,
        first_names[mod(i, array_length(first_names, 1)) + 1],
        last_names[mod(i, array_length(last_names, 1)) + 1],
@@ -33,7 +34,8 @@ SELECT 'id' || i::text,
        CASE mod(i, 7)
            WHEN 0 THEN 'Latvia'
            ELSE country[mod(i, array_length(country, 1)) + 1] END,
-       extra_information[mod(i, array_length(extra_information, 1)) + 1]
+       extra_information[mod(i, array_length(extra_information, 1)) + 1],
+       mod(i, 19) <> 0
 FROM generate_series(1, 4900) AS i,
      (SELECT ('{Antti, Eero, Ilkka, Jari, Juha, Matti, Pekka, Timo, Iiro, Jukka, Kalle, ' ||
               'Kari, Marko, Mikko, Tapani, Ville, Anneli, Ella, Hanna, Iiris, Liisa, ' ||

--- a/db/4_init.sql
+++ b/db/4_init.sql
@@ -18,7 +18,7 @@ INSERT INTO meeting_date(date)
 VALUES ('2025-01-01');
 
 INSERT INTO translator(identity_number, first_name, last_name, email, phone_number, street, town, postal_code, country,
-                       extra_information, is_assured)
+                       extra_information, is_assurance_given)
 SELECT 'id' || i::text,
        first_names[mod(i, array_length(first_names, 1)) + 1],
        last_names[mod(i, array_length(last_names, 1)) + 1],

--- a/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorDTO.java
@@ -17,6 +17,7 @@ public record ClerkTranslatorDTO(
   String town,
   String country,
   String extraInformation,
+  @NonNull Boolean isAssured,
   @NonNull List<AuthorisationDTO> authorisations
 ) {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/ClerkTranslatorDTO.java
@@ -17,7 +17,7 @@ public record ClerkTranslatorDTO(
   String town,
   String country,
   String extraInformation,
-  @NonNull Boolean isAssured,
+  @NonNull Boolean isAssuranceGiven,
   @NonNull List<AuthorisationDTO> authorisations
 ) {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
@@ -18,6 +18,7 @@ public record TranslatorCreateDTO(
   String town,
   String country,
   String extraInformation,
+  @NonNull Boolean isAssured,
   @NonNull @NotEmpty List<AuthorisationCreateDTO> authorisations
 )
   implements TranslatorDTOCommonFields {

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
@@ -18,7 +18,7 @@ public record TranslatorCreateDTO(
   String town,
   String country,
   String extraInformation,
-  @NonNull Boolean isAssured,
+  @NonNull Boolean isAssuranceGiven,
   @NonNull @NotEmpty List<AuthorisationCreateDTO> authorisations
 )
   implements TranslatorDTOCommonFields {

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorDTOCommonFields.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorDTOCommonFields.java
@@ -20,4 +20,6 @@ public interface TranslatorDTOCommonFields {
   String country();
 
   String extraInformation();
+
+  Boolean isAssured();
 }

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorDTOCommonFields.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorDTOCommonFields.java
@@ -21,5 +21,5 @@ public interface TranslatorDTOCommonFields {
 
   String extraInformation();
 
-  Boolean isAssured();
+  Boolean isAssuranceGiven();
 }

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
@@ -18,7 +18,8 @@ public record TranslatorUpdateDTO(
   String postalCode,
   String town,
   String country,
-  String extraInformation
+  String extraInformation,
+  @NonNull Boolean isAssured
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
@@ -19,7 +19,7 @@ public record TranslatorUpdateDTO(
   String town,
   String country,
   String extraInformation,
-  @NonNull Boolean isAssured
+  @NonNull Boolean isAssuranceGiven
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/model/Translator.java
+++ b/src/main/java/fi/oph/akt/model/Translator.java
@@ -62,6 +62,9 @@ public class Translator extends BaseEntity {
   @Column(name = "extra_information")
   private String extraInformation;
 
+  @Column(name = "is_assured", nullable = false)
+  private boolean isAssured;
+
   public String getFullName() {
     return firstName + " " + lastName;
   }

--- a/src/main/java/fi/oph/akt/model/Translator.java
+++ b/src/main/java/fi/oph/akt/model/Translator.java
@@ -62,8 +62,8 @@ public class Translator extends BaseEntity {
   @Column(name = "extra_information")
   private String extraInformation;
 
-  @Column(name = "is_assured", nullable = false)
-  private boolean isAssured;
+  @Column(name = "is_assurance_given", nullable = false)
+  private boolean isAssuranceGiven;
 
   public String getFullName() {
     return firstName + " " + lastName;

--- a/src/main/java/fi/oph/akt/repository/AuthorisationRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationRepository.java
@@ -21,7 +21,7 @@ public interface AuthorisationRepository extends JpaRepository<Authorisation, Lo
     "SELECT new fi.oph.akt.repository.TranslatorLanguagePairProjection(t.id, a.fromLang, a.toLang)" +
     " FROM Authorisation a" +
     " JOIN a.translator t" +
-    " WHERE a.permissionToPublish = true" +
+    " WHERE t.isAssured = true AND a.permissionToPublish = true" +
     " AND a.termBeginDate IS NOT NULL AND CURRENT_DATE >= a.termBeginDate" +
     " AND (a.termEndDate IS NULL OR CURRENT_DATE <= a.termEndDate)" +
     " GROUP BY t.id, a.fromLang, a.toLang"

--- a/src/main/java/fi/oph/akt/repository/AuthorisationRepository.java
+++ b/src/main/java/fi/oph/akt/repository/AuthorisationRepository.java
@@ -21,7 +21,7 @@ public interface AuthorisationRepository extends JpaRepository<Authorisation, Lo
     "SELECT new fi.oph.akt.repository.TranslatorLanguagePairProjection(t.id, a.fromLang, a.toLang)" +
     " FROM Authorisation a" +
     " JOIN a.translator t" +
-    " WHERE t.isAssured = true AND a.permissionToPublish = true" +
+    " WHERE t.isAssuranceGiven = true AND a.permissionToPublish = true" +
     " AND a.termBeginDate IS NOT NULL AND CURRENT_DATE >= a.termBeginDate" +
     " AND (a.termEndDate IS NULL OR CURRENT_DATE <= a.termEndDate)" +
     " GROUP BY t.id, a.fromLang, a.toLang"

--- a/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
+++ b/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
@@ -122,7 +122,7 @@ public class ClerkTranslatorService {
           .town(translator.getTown())
           .country(translator.getCountry())
           .extraInformation(translator.getExtraInformation())
-          .isAssured(translator.isAssured())
+          .isAssuranceGiven(translator.isAssuranceGiven())
           .authorisations(authorisationDTOS)
           .build();
       })
@@ -227,7 +227,7 @@ public class ClerkTranslatorService {
     translator.setPostalCode(dto.postalCode());
     translator.setCountry(dto.country());
     translator.setExtraInformation(dto.extraInformation());
-    translator.setAssured(dto.isAssured());
+    translator.setAssuranceGiven(dto.isAssuranceGiven());
   }
 
   @Transactional

--- a/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
+++ b/src/main/java/fi/oph/akt/service/ClerkTranslatorService.java
@@ -122,6 +122,7 @@ public class ClerkTranslatorService {
           .town(translator.getTown())
           .country(translator.getCountry())
           .extraInformation(translator.getExtraInformation())
+          .isAssured(translator.isAssured())
           .authorisations(authorisationDTOS)
           .build();
       })
@@ -226,6 +227,7 @@ public class ClerkTranslatorService {
     translator.setPostalCode(dto.postalCode());
     translator.setCountry(dto.country());
     translator.setExtraInformation(dto.extraInformation());
+    translator.setAssured(dto.isAssured());
   }
 
   @Transactional

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -11,6 +11,7 @@ import {
 import { ClerkTranslatorDetailsFieldProps } from 'interfaces/clerkTranslatorDetailsField';
 import { Utils } from 'utils';
 
+// TODO: should return something else for 'isAssured' than Text
 const getFieldType = (field: keyof ClerkTranslatorBasicInformation) => {
   switch (field) {
     case 'phoneNumber':
@@ -28,10 +29,14 @@ const getFieldError = (
   translator: ClerkTranslator | undefined,
   field: keyof ClerkTranslatorBasicInformation
 ) => {
-  const type = getFieldType(field);
-  const fieldValue = (translator && translator[field]) || '';
+  if (field !== 'isAssured') {
+    const type = getFieldType(field);
+    const fieldValue = (translator && translator[field]) || '';
 
-  return Utils.inspectCustomTextFieldErrors(type, fieldValue, false) || '';
+    return Utils.inspectCustomTextFieldErrors(type, fieldValue, false) || '';
+  }
+
+  return '';
 };
 
 const ClerkTranslatorDetailsField = ({

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -7,44 +7,40 @@ import { TextFieldTypes } from 'enums/app';
 import {
   ClerkTranslator,
   ClerkTranslatorBasicInformation,
+  ClerkTranslatorTextField,
 } from 'interfaces/clerkTranslator';
-import { ClerkTranslatorDetailsFieldProps } from 'interfaces/clerkTranslatorDetailsField';
+import { ClerkTranslatorTextFieldProps } from 'interfaces/clerkTranslatorTextField';
 import { Utils } from 'utils';
 
-// TODO: should return something else for 'isAssured' than Text
-const getFieldType = (field: keyof ClerkTranslatorBasicInformation) => {
-  switch (field) {
-    case 'phoneNumber':
-      return TextFieldTypes.PhoneNumber;
-    case 'email':
-      return TextFieldTypes.Email;
-    case 'extraInformation':
-      return TextFieldTypes.Textarea;
-    default:
-      return TextFieldTypes.Text;
-  }
-};
-
-const getFieldError = (
-  translator: ClerkTranslator | undefined,
-  field: keyof ClerkTranslatorBasicInformation
-) => {
-  if (field !== 'isAssured') {
-    const type = getFieldType(field);
-    const fieldValue = (translator && translator[field]) || '';
-
-    return Utils.inspectCustomTextFieldErrors(type, fieldValue, false) || '';
-  }
-
-  return '';
-};
-
-const ClerkTranslatorDetailsField = ({
+const ClerkTranslatorDetailsTextField = ({
   translator,
   field,
   onChange,
   ...rest
-}: ClerkTranslatorDetailsFieldProps) => {
+}: ClerkTranslatorTextFieldProps) => {
+  const getFieldType = (field: keyof ClerkTranslatorTextField) => {
+    switch (field) {
+      case 'phoneNumber':
+        return TextFieldTypes.PhoneNumber;
+      case 'email':
+        return TextFieldTypes.Email;
+      case 'extraInformation':
+        return TextFieldTypes.Textarea;
+      default:
+        return TextFieldTypes.Text;
+    }
+  };
+
+  const getFieldError = (
+    translator: ClerkTranslator | undefined,
+    field: keyof ClerkTranslatorTextField
+  ) => {
+    const type = getFieldType(field);
+    const fieldValue = (translator && translator[field]) || '';
+
+    return Utils.inspectCustomTextFieldErrors(type, fieldValue, false) || '';
+  };
+
   // I18n
   const { t } = useAppTranslation({
     keyPrefix: 'akt.component.clerkTranslatorOverview.translatorDetails.fields',
@@ -82,9 +78,7 @@ export const ClerkTranslatorDetailsFields = ({
     keyPrefix: 'akt.component.clerkTranslatorOverview.translatorDetails',
   });
 
-  const getCommonTextFieldProps = (
-    field: keyof ClerkTranslatorBasicInformation
-  ) => ({
+  const getCommonTextFieldProps = (field: keyof ClerkTranslatorTextField) => ({
     field,
     translator,
     disabled: editDisabled,
@@ -100,32 +94,40 @@ export const ClerkTranslatorDetailsFields = ({
         {controlButtons}
       </div>
       <div className="grid-columns gapped">
-        <ClerkTranslatorDetailsField {...getCommonTextFieldProps('lastName')} />
-        <ClerkTranslatorDetailsField
+        <ClerkTranslatorDetailsTextField
+          {...getCommonTextFieldProps('lastName')}
+        />
+        <ClerkTranslatorDetailsTextField
           {...getCommonTextFieldProps('firstName')}
         />
-        <ClerkTranslatorDetailsField
+        <ClerkTranslatorDetailsTextField
           {...getCommonTextFieldProps('identityNumber')}
         />
       </div>
       <H3>{t('header.address')}</H3>
       <div className="grid-columns gapped">
-        <ClerkTranslatorDetailsField {...getCommonTextFieldProps('street')} />
-        <ClerkTranslatorDetailsField
+        <ClerkTranslatorDetailsTextField
+          {...getCommonTextFieldProps('street')}
+        />
+        <ClerkTranslatorDetailsTextField
           {...getCommonTextFieldProps('postalCode')}
         />
-        <ClerkTranslatorDetailsField {...getCommonTextFieldProps('town')} />
-        <ClerkTranslatorDetailsField {...getCommonTextFieldProps('country')} />
+        <ClerkTranslatorDetailsTextField {...getCommonTextFieldProps('town')} />
+        <ClerkTranslatorDetailsTextField
+          {...getCommonTextFieldProps('country')}
+        />
       </div>
       <H3>{t('header.contactInformation')}</H3>
       <div className="grid-columns gapped">
-        <ClerkTranslatorDetailsField {...getCommonTextFieldProps('email')} />
-        <ClerkTranslatorDetailsField
+        <ClerkTranslatorDetailsTextField
+          {...getCommonTextFieldProps('email')}
+        />
+        <ClerkTranslatorDetailsTextField
           {...getCommonTextFieldProps('phoneNumber')}
         />
       </div>
       <H3>{t('header.extraInformation')}</H3>
-      <ClerkTranslatorDetailsField
+      <ClerkTranslatorDetailsTextField
         {...getCommonTextFieldProps('extraInformation')}
         multiline
         fullWidth

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -7,9 +7,11 @@ import { TextFieldTypes } from 'enums/app';
 import {
   ClerkTranslator,
   ClerkTranslatorBasicInformation,
-  ClerkTranslatorTextField,
 } from 'interfaces/clerkTranslator';
-import { ClerkTranslatorTextFieldProps } from 'interfaces/clerkTranslatorTextField';
+import {
+  ClerkTranslatorTextField,
+  ClerkTranslatorTextFieldProps,
+} from 'interfaces/clerkTranslatorTextField';
 import { Utils } from 'utils';
 
 const ClerkTranslatorDetailsTextField = ({

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -8,7 +8,7 @@ import {
 import { WithId } from 'interfaces/withId';
 import { WithVersion } from 'interfaces/withVersion';
 
-export interface ClerkTranslatorBasicInformation {
+export interface ClerkTranslatorTextField {
   firstName: string;
   lastName: string;
   identityNumber?: string;
@@ -19,6 +19,10 @@ export interface ClerkTranslatorBasicInformation {
   town?: string;
   country?: string;
   extraInformation?: string;
+}
+
+export interface ClerkTranslatorBasicInformation
+  extends ClerkTranslatorTextField {
   isAssured: boolean;
 }
 

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -8,7 +8,7 @@ import {
 import { WithId } from 'interfaces/withId';
 import { WithVersion } from 'interfaces/withVersion';
 
-export interface ClerkTranslatorTextField {
+export interface ClerkTranslatorBasicInformation {
   firstName: string;
   lastName: string;
   identityNumber?: string;
@@ -19,10 +19,6 @@ export interface ClerkTranslatorTextField {
   town?: string;
   country?: string;
   extraInformation?: string;
-}
-
-export interface ClerkTranslatorBasicInformation
-  extends ClerkTranslatorTextField {
   isAssuranceGiven: boolean;
 }
 

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -23,7 +23,7 @@ export interface ClerkTranslatorTextField {
 
 export interface ClerkTranslatorBasicInformation
   extends ClerkTranslatorTextField {
-  isAssured: boolean;
+  isAssuranceGiven: boolean;
 }
 
 export interface ClerkTranslatorResponse

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -19,6 +19,7 @@ export interface ClerkTranslatorBasicInformation {
   town?: string;
   country?: string;
   extraInformation?: string;
+  isAssured: boolean;
 }
 
 export interface ClerkTranslatorResponse

--- a/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
@@ -2,12 +2,12 @@ import { ChangeEvent } from 'react';
 
 import {
   ClerkTranslator,
-  ClerkTranslatorBasicInformation,
+  ClerkTranslatorTextField,
 } from 'interfaces/clerkTranslator';
 import { CustomTextFieldProps } from 'interfaces/customTextField';
 
-export type ClerkTranslatorDetailsFieldProps = {
+export type ClerkTranslatorTextFieldProps = {
   translator?: ClerkTranslator;
-  field: keyof ClerkTranslatorBasicInformation;
+  field: keyof ClerkTranslatorTextField;
   onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 } & CustomTextFieldProps;

--- a/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
@@ -2,9 +2,14 @@ import { ChangeEvent } from 'react';
 
 import {
   ClerkTranslator,
-  ClerkTranslatorTextField,
+  ClerkTranslatorBasicInformation,
 } from 'interfaces/clerkTranslator';
 import { CustomTextFieldProps } from 'interfaces/customTextField';
+
+export type ClerkTranslatorTextField = Omit<
+  ClerkTranslatorBasicInformation,
+  'isAssuranceGiven'
+>;
 
 export type ClerkTranslatorTextFieldProps = {
   translator?: ClerkTranslator;

--- a/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_10.json
+++ b/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_10.json
@@ -96,7 +96,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 1,
@@ -143,7 +143,7 @@
       "town": "Hämeenlinna",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 2,
@@ -190,7 +190,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 3,
@@ -235,7 +235,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Lahti",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 4,
@@ -282,7 +282,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5,
@@ -329,7 +329,7 @@
       "town": "Vantaa",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 6,
@@ -376,7 +376,7 @@
       "town": "Ääpnevräj",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 7,
@@ -423,7 +423,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 8,
@@ -468,7 +468,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Tampere",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 9,
@@ -515,7 +515,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 10,

--- a/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_10.json
+++ b/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_10.json
@@ -96,6 +96,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 1,
@@ -142,6 +143,7 @@
       "town": "Hämeenlinna",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 2,
@@ -188,6 +190,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 3,
@@ -232,6 +235,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Lahti",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 4,
@@ -278,6 +282,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5,
@@ -324,6 +329,7 @@
       "town": "Vantaa",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 6,
@@ -370,6 +376,7 @@
       "town": "Ääpnevräj",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 7,
@@ -416,6 +423,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 8,
@@ -460,6 +468,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Tampere",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 9,
@@ -506,6 +515,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 10,

--- a/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_100.json
+++ b/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_100.json
@@ -142,6 +142,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 1,
@@ -188,6 +189,7 @@
       "town": "Hämeenlinna",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 2,
@@ -234,6 +236,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 3,
@@ -278,6 +281,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Lahti",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 4,
@@ -324,6 +328,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5,
@@ -370,6 +375,7 @@
       "town": "Vantaa",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 6,
@@ -416,6 +422,7 @@
       "town": "Ääpnevräj",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 7,
@@ -462,6 +469,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 8,
@@ -506,6 +514,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Tampere",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 9,
@@ -552,6 +561,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 10,
@@ -597,6 +607,7 @@
       "town": "Rovaniemi",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 11,
@@ -641,6 +652,7 @@
       "town": "Kajaani",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 12,
@@ -687,6 +699,7 @@
       "town": "Joensuu",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 13,
@@ -758,6 +771,7 @@
       "postalCode": "00100",
       "town": "Iknupuakisuu",
       "country": "Latvia",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 14,
@@ -804,6 +818,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 15,
@@ -872,6 +887,7 @@
       "town": "Kotka",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 16,
@@ -918,6 +934,7 @@
       "town": "Helsinki",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5603,
@@ -986,6 +1003,7 @@
       "town": "Turku",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 18,
@@ -1030,6 +1048,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Hämeenlinna",
+      "isAssured": false,
       "authorisations": [
         {
           "id": 19,
@@ -1106,6 +1125,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 20,
@@ -1167,6 +1187,7 @@
       "town": "Ithal",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 21,
@@ -1242,6 +1263,7 @@
       "town": "Porvoo",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 22,
@@ -1316,6 +1338,7 @@
       "town": "Vantaa",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 23,
@@ -1390,6 +1413,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Järvenpää",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 24,
@@ -1464,6 +1488,7 @@
       "town": "Kouvola",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 25,
@@ -1510,6 +1535,7 @@
       "town": "Tampere",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 26,
@@ -1582,6 +1608,7 @@
       "town": "Oulu",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 27,
@@ -1628,6 +1655,7 @@
       "town": "Imeinavor",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 28,
@@ -1672,6 +1700,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Kajaani",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 29,
@@ -1718,6 +1747,7 @@
       "town": "Joensuu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 30,
@@ -1794,6 +1824,7 @@
       "town": "Uusikaupunki",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 31,
@@ -1840,6 +1871,7 @@
       "town": "Kuopio",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 32,
@@ -1885,6 +1917,7 @@
       "town": "Kotka",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 33,
@@ -1927,6 +1960,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "54460",
       "town": "Helsinki",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5604,
@@ -1995,6 +2029,7 @@
       "town": "Ukrut",
       "country": "Latvia",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 35,
@@ -2041,6 +2076,7 @@
       "town": "Hämeenlinna",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 36,
@@ -2087,6 +2123,7 @@
       "town": "Kuopio",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 37,
@@ -2133,6 +2170,7 @@
       "town": "Lahti",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": false,
       "authorisations": [
         {
           "id": 38,
@@ -2207,6 +2245,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Porvoo",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 39,
@@ -2279,6 +2318,7 @@
       "town": "Vantaa",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 40,
@@ -2340,6 +2380,7 @@
       "town": "Järvenpää",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 41,
@@ -2386,6 +2427,7 @@
       "town": "Alovuok",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 42,
@@ -2462,6 +2504,7 @@
       "town": "Tampere",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 43,
@@ -2505,6 +2548,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Oulu",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 44,
@@ -2571,6 +2615,7 @@
       "town": "Rovaniemi",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 45,
@@ -2647,6 +2692,7 @@
       "town": "Kajaani",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 46,
@@ -2723,6 +2769,7 @@
       "town": "Joensuu",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 47,
@@ -2769,6 +2816,7 @@
       "town": "Uusikaupunki",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 48,
@@ -2844,6 +2892,7 @@
       "postalCode": "00100",
       "town": "Oipouk",
       "country": "Latvia",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 49,
@@ -2888,6 +2937,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Kuopio",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 54,
@@ -2934,6 +2984,7 @@
       "town": "Oovrop",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 56,
@@ -2980,6 +3031,7 @@
       "town": "Vantaa",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": false,
       "authorisations": [
         {
           "id": 57,
@@ -3056,6 +3108,7 @@
       "town": "Järvenpää",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 58,
@@ -3100,6 +3153,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Kouvola",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 59,
@@ -3146,6 +3200,7 @@
       "town": "Tampere",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 60,
@@ -3218,6 +3273,7 @@
       "town": "Oulu",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 61,
@@ -3263,6 +3319,7 @@
       "town": "Kotka",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 50,
@@ -3308,6 +3365,7 @@
       "town": "Helsinki",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5605,
@@ -3374,6 +3432,7 @@
       "town": "Lahti",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 55,
@@ -3418,6 +3477,7 @@
       "town": "Rovaniemi",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 62,
@@ -3464,6 +3524,7 @@
       "town": "Inaajak",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 63,
@@ -3538,6 +3599,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Joensuu",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 64,
@@ -3584,6 +3646,7 @@
       "town": "Uusikaupunki",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 65,
@@ -3653,6 +3716,7 @@
       "town": "Kuopio",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 66,
@@ -3727,6 +3791,7 @@
       "town": "Kotka",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 67,
@@ -3773,6 +3838,7 @@
       "town": "Helsinki",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5606,
@@ -3839,6 +3905,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "54460",
       "town": "Turku",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 69,
@@ -3913,6 +3980,7 @@
       "town": "Annilneemäh",
       "country": "Latvia",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 70,
@@ -3959,6 +4027,7 @@
       "town": "Kuopio",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 71,
@@ -4005,6 +4074,7 @@
       "town": "Lahti",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 72,
@@ -4081,6 +4151,7 @@
       "town": "Porvoo",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 73,
@@ -4125,6 +4196,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Vantaa",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 74,
@@ -4171,6 +4243,7 @@
       "town": "Järvenpää",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 75,
@@ -4245,6 +4318,7 @@
       "town": "Kouvola",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": false,
       "authorisations": [
         {
           "id": 76,
@@ -4320,6 +4394,7 @@
       "town": "Erepmat",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 77,
@@ -4364,6 +4439,7 @@
       "town": "Oulu",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 78,
@@ -4434,6 +4510,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Rovaniemi",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 79,
@@ -4480,6 +4557,7 @@
       "town": "Kajaani",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 80,
@@ -4533,6 +4611,7 @@
       "town": "Joensuu",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 81,
@@ -4567,60 +4646,61 @@
       ]
     },
     {
-      "id": 400,
+      "id": 200,
       "version": 0,
-      "firstName": "Marjatta",
-      "lastName": "Manninen",
-      "email": "translator400@example.invalid",
-      "phoneNumber": "+358401000400",
+      "firstName": "Tapani",
+      "lastName": "Karjalainen",
+      "email": "translator200@example.invalid",
+      "phoneNumber": "+358401000200",
       "street": "Malminkatu 1",
-      "postalCode": "01200",
-      "town": "Tampere",
+      "postalCode": "31600",
+      "town": "Joensuu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
-          "id": 400,
+          "id": 200,
           "version": 0,
           "languagePair": {
             "from": "FI",
-            "to": "FO"
+            "to": "RU"
           },
           "basis": "AUT",
           "termBeginDate": "2022-01-01",
-          "termEndDate": "2023-02-19",
+          "termEndDate": "2022-08-03",
           "permissionToPublish": true,
-          "diaryNumber": "400",
+          "diaryNumber": "200",
           "meetingDate": "2021-12-20",
           "autDate": "2022-03-03"
         },
         {
-          "id": 6167,
+          "id": 6157,
           "version": 0,
           "languagePair": {
             "from": "SEIN",
-            "to": "HU"
+            "to": "UK"
           },
           "basis": "AUT",
           "termBeginDate": "2022-01-01",
-          "termEndDate": "2023-02-19",
+          "termEndDate": "2022-08-03",
           "permissionToPublish": true,
-          "diaryNumber": "6167",
+          "diaryNumber": "6157",
           "meetingDate": "2021-12-20",
           "autDate": "2022-03-03"
         },
         {
-          "id": 13123,
+          "id": 13114,
           "version": 0,
           "languagePair": {
-            "from": "HU",
+            "from": "UK",
             "to": "SEIN"
           },
           "basis": "AUT",
           "termBeginDate": "2022-01-01",
-          "termEndDate": "2023-02-19",
+          "termEndDate": "2022-08-03",
           "permissionToPublish": true,
-          "diaryNumber": "13123",
+          "diaryNumber": "13114",
           "meetingDate": "2021-12-20",
           "autDate": "2022-03-03"
         }
@@ -4639,6 +4719,7 @@
       "town": "Uusikaupunki",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 82,
@@ -4685,6 +4766,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 83,
@@ -4730,6 +4812,7 @@
       "postalCode": "00100",
       "town": "Aktok",
       "country": "Latvia",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 84,
@@ -4806,6 +4889,7 @@
       "town": "Helsinki",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 5607,
@@ -4872,6 +4956,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 86,
@@ -4917,6 +5002,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 88,
@@ -4989,6 +5075,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Lahti",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 89,
@@ -5035,6 +5122,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 90,
@@ -5111,6 +5199,7 @@
       "town": "Aatnav",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 91,
@@ -5183,6 +5272,7 @@
       "town": "Järvenpää",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 92,
@@ -5259,6 +5349,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 93,
@@ -5303,6 +5394,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Tampere",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 94,
@@ -5349,6 +5441,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": false,
       "authorisations": [
         {
           "id": 95,
@@ -5423,6 +5516,7 @@
       "town": "Rovaniemi",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 96,
@@ -5499,6 +5593,7 @@
       "town": "Kajaani",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 97,
@@ -5545,6 +5640,7 @@
       "town": "Uusneoj",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 98,
@@ -5588,6 +5684,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Uusikaupunki",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 99,
@@ -5632,6 +5729,7 @@
       "town": "Kotka",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 101,
@@ -5677,6 +5775,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 100,
@@ -5738,6 +5837,7 @@
       "town": "Turku",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
+      "isAssured": true,
       "authorisations": [
         {
           "id": 103,

--- a/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_100.json
+++ b/src/main/reactjs/src/tests/cypress/fixtures/clerk_translators_100.json
@@ -142,7 +142,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 1,
@@ -189,7 +189,7 @@
       "town": "Hämeenlinna",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 2,
@@ -236,7 +236,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 3,
@@ -281,7 +281,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Lahti",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 4,
@@ -328,7 +328,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5,
@@ -375,7 +375,7 @@
       "town": "Vantaa",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 6,
@@ -422,7 +422,7 @@
       "town": "Ääpnevräj",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 7,
@@ -469,7 +469,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 8,
@@ -514,7 +514,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Tampere",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 9,
@@ -561,7 +561,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 10,
@@ -607,7 +607,7 @@
       "town": "Rovaniemi",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 11,
@@ -652,7 +652,7 @@
       "town": "Kajaani",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 12,
@@ -699,7 +699,7 @@
       "town": "Joensuu",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 13,
@@ -771,7 +771,7 @@
       "postalCode": "00100",
       "town": "Iknupuakisuu",
       "country": "Latvia",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 14,
@@ -818,7 +818,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 15,
@@ -887,7 +887,7 @@
       "town": "Kotka",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 16,
@@ -934,7 +934,7 @@
       "town": "Helsinki",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5603,
@@ -1003,7 +1003,7 @@
       "town": "Turku",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 18,
@@ -1048,7 +1048,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Hämeenlinna",
-      "isAssured": false,
+      "isAssuranceGiven": false,
       "authorisations": [
         {
           "id": 19,
@@ -1125,7 +1125,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 20,
@@ -1187,7 +1187,7 @@
       "town": "Ithal",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 21,
@@ -1263,7 +1263,7 @@
       "town": "Porvoo",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 22,
@@ -1338,7 +1338,7 @@
       "town": "Vantaa",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 23,
@@ -1413,7 +1413,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Järvenpää",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 24,
@@ -1488,7 +1488,7 @@
       "town": "Kouvola",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 25,
@@ -1535,7 +1535,7 @@
       "town": "Tampere",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 26,
@@ -1608,7 +1608,7 @@
       "town": "Oulu",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 27,
@@ -1655,7 +1655,7 @@
       "town": "Imeinavor",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 28,
@@ -1700,7 +1700,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Kajaani",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 29,
@@ -1747,7 +1747,7 @@
       "town": "Joensuu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 30,
@@ -1824,7 +1824,7 @@
       "town": "Uusikaupunki",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 31,
@@ -1871,7 +1871,7 @@
       "town": "Kuopio",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 32,
@@ -1917,7 +1917,7 @@
       "town": "Kotka",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 33,
@@ -1960,7 +1960,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "54460",
       "town": "Helsinki",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5604,
@@ -2029,7 +2029,7 @@
       "town": "Ukrut",
       "country": "Latvia",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 35,
@@ -2076,7 +2076,7 @@
       "town": "Hämeenlinna",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 36,
@@ -2123,7 +2123,7 @@
       "town": "Kuopio",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 37,
@@ -2170,7 +2170,7 @@
       "town": "Lahti",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": false,
+      "isAssuranceGiven": false,
       "authorisations": [
         {
           "id": 38,
@@ -2245,7 +2245,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Porvoo",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 39,
@@ -2318,7 +2318,7 @@
       "town": "Vantaa",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 40,
@@ -2380,7 +2380,7 @@
       "town": "Järvenpää",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 41,
@@ -2427,7 +2427,7 @@
       "town": "Alovuok",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 42,
@@ -2504,7 +2504,7 @@
       "town": "Tampere",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 43,
@@ -2548,7 +2548,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Oulu",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 44,
@@ -2615,7 +2615,7 @@
       "town": "Rovaniemi",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 45,
@@ -2692,7 +2692,7 @@
       "town": "Kajaani",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 46,
@@ -2769,7 +2769,7 @@
       "town": "Joensuu",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 47,
@@ -2816,7 +2816,7 @@
       "town": "Uusikaupunki",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 48,
@@ -2892,7 +2892,7 @@
       "postalCode": "00100",
       "town": "Oipouk",
       "country": "Latvia",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 49,
@@ -2937,7 +2937,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Kuopio",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 54,
@@ -2984,7 +2984,7 @@
       "town": "Oovrop",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 56,
@@ -3031,7 +3031,7 @@
       "town": "Vantaa",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": false,
+      "isAssuranceGiven": false,
       "authorisations": [
         {
           "id": 57,
@@ -3108,7 +3108,7 @@
       "town": "Järvenpää",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 58,
@@ -3153,7 +3153,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Kouvola",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 59,
@@ -3200,7 +3200,7 @@
       "town": "Tampere",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 60,
@@ -3273,7 +3273,7 @@
       "town": "Oulu",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 61,
@@ -3319,7 +3319,7 @@
       "town": "Kotka",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 50,
@@ -3365,7 +3365,7 @@
       "town": "Helsinki",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5605,
@@ -3432,7 +3432,7 @@
       "town": "Lahti",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 55,
@@ -3477,7 +3477,7 @@
       "town": "Rovaniemi",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 62,
@@ -3524,7 +3524,7 @@
       "town": "Inaajak",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 63,
@@ -3599,7 +3599,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Joensuu",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 64,
@@ -3646,7 +3646,7 @@
       "town": "Uusikaupunki",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 65,
@@ -3716,7 +3716,7 @@
       "town": "Kuopio",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 66,
@@ -3791,7 +3791,7 @@
       "town": "Kotka",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 67,
@@ -3838,7 +3838,7 @@
       "town": "Helsinki",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5606,
@@ -3905,7 +3905,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "54460",
       "town": "Turku",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 69,
@@ -3980,7 +3980,7 @@
       "town": "Annilneemäh",
       "country": "Latvia",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 70,
@@ -4027,7 +4027,7 @@
       "town": "Kuopio",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 71,
@@ -4074,7 +4074,7 @@
       "town": "Lahti",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 72,
@@ -4151,7 +4151,7 @@
       "town": "Porvoo",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 73,
@@ -4196,7 +4196,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "31600",
       "town": "Vantaa",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 74,
@@ -4243,7 +4243,7 @@
       "town": "Järvenpää",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 75,
@@ -4318,7 +4318,7 @@
       "town": "Kouvola",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": false,
+      "isAssuranceGiven": false,
       "authorisations": [
         {
           "id": 76,
@@ -4394,7 +4394,7 @@
       "town": "Erepmat",
       "country": "Latvia",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 77,
@@ -4439,7 +4439,7 @@
       "town": "Oulu",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 78,
@@ -4510,7 +4510,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "06100",
       "town": "Rovaniemi",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 79,
@@ -4557,7 +4557,7 @@
       "town": "Kajaani",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 80,
@@ -4611,7 +4611,7 @@
       "town": "Joensuu",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 81,
@@ -4657,7 +4657,7 @@
       "town": "Joensuu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 200,
@@ -4719,7 +4719,7 @@
       "town": "Uusikaupunki",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 82,
@@ -4766,7 +4766,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 83,
@@ -4812,7 +4812,7 @@
       "postalCode": "00100",
       "town": "Aktok",
       "country": "Latvia",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 84,
@@ -4889,7 +4889,7 @@
       "town": "Helsinki",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 5607,
@@ -4956,7 +4956,7 @@
       "town": "Turku",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 86,
@@ -5002,7 +5002,7 @@
       "town": "Kuopio",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 88,
@@ -5075,7 +5075,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "48600",
       "town": "Lahti",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 89,
@@ -5122,7 +5122,7 @@
       "town": "Porvoo",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 90,
@@ -5199,7 +5199,7 @@
       "town": "Aatnav",
       "country": "Latvia",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 91,
@@ -5272,7 +5272,7 @@
       "town": "Järvenpää",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 92,
@@ -5349,7 +5349,7 @@
       "town": "Kouvola",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 93,
@@ -5394,7 +5394,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "13500",
       "town": "Tampere",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 94,
@@ -5441,7 +5441,7 @@
       "town": "Oulu",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": false,
+      "isAssuranceGiven": false,
       "authorisations": [
         {
           "id": 95,
@@ -5516,7 +5516,7 @@
       "town": "Rovaniemi",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 96,
@@ -5593,7 +5593,7 @@
       "town": "Kajaani",
       "country": "SUOMI",
       "extraInformation": "Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 97,
@@ -5640,7 +5640,7 @@
       "town": "Uusneoj",
       "country": "Latvia",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 98,
@@ -5684,7 +5684,7 @@
       "street": "Pirkkolantie 123",
       "postalCode": "01200",
       "town": "Uusikaupunki",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 99,
@@ -5729,7 +5729,7 @@
       "town": "Kotka",
       "country": "suomi",
       "extraInformation": "Kääntäjän nimeä muutettu. Vanhassa nimessä oli typo.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 101,
@@ -5775,7 +5775,7 @@
       "town": "Kuopio",
       "country": "Suomi",
       "extraInformation": "Osoitetiedot päivitetty 1.1.1970.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 100,
@@ -5837,7 +5837,7 @@
       "town": "Turku",
       "country": "Finland",
       "extraInformation": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut vehicula sem nulla eu placerat libero dapibus eget. Ut ac pretium velit ac hendrerit eros. Nullam in tortor in augue dignissim vehicula. Nulla ac cursus ligula. Nulla ut magna dapibus egestas tortor eget consequat augue. Pellentesque tempor sapien ut orci commodo et commodo mi condimentum. Aliquam lacinia commodo elit id bibendum quam condimentum suscipit. Phasellus nibh turpis laoreet non gravida sed gravida ac magna. Nulla ut lectus augue. Curabitur finibus laoreet ullamcorper. Nullam id dapibus ex et fermentum nulla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas varius lectus id felis mattis ac sodales purus posuere. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed a pharetra massa.",
-      "isAssured": true,
+      "isAssuranceGiven": true,
       "authorisations": [
         {
           "id": 103,

--- a/src/main/reactjs/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
+++ b/src/main/reactjs/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
@@ -157,6 +157,7 @@ export const translatorResponse: ClerkTranslatorResponse = {
   country: 'SUOMI',
   extraInformation:
     'Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen',
+  isAssured: true,
   authorisations: [
     {
       id: 2,

--- a/src/main/reactjs/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
+++ b/src/main/reactjs/src/tests/cypress/support/page-objects/clerkTranslatorOverviewPage.ts
@@ -157,7 +157,7 @@ export const translatorResponse: ClerkTranslatorResponse = {
   country: 'SUOMI',
   extraInformation:
     'Osoitetietoja muokattu 1.5.1999. Osoitetietoja muutettu uudelleen 2.5.1999. Uusi auktorisointi lisätty kääntäjälle 12.10.2000. Auktorisointi päivitetty julkiseksi 1.1.2001. Viimeisen muutoksen tekijä: Testi Testinen',
-  isAssured: true,
+  isAssuranceGiven: true,
   authorisations: [
     {
       id: 2,

--- a/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -594,14 +594,14 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="2022-03-04-add_translator_has_assurance" author="mikhuttu">
+    <changeSet id="2022-03-04-add_translator_is_assurance_given" author="mikhuttu">
         <addColumn tableName="translator">
-            <column name="is_assured" type="BOOL" defaultValueBoolean="true">
+            <column name="is_assurance_given" type="BOOL" defaultValueBoolean="true">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
 
-        <dropDefaultValue tableName="translator" columnName="is_assured"/>
+        <dropDefaultValue tableName="translator" columnName="is_assurance_given"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -594,4 +594,14 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="2022-03-04-add_translator_has_assurance" author="mikhuttu">
+        <addColumn tableName="translator">
+            <column name="is_assured" type="BOOL" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <dropDefaultValue tableName="translator" columnName="is_assured"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/fi/oph/akt/Factory.java
+++ b/src/test/java/fi/oph/akt/Factory.java
@@ -26,6 +26,7 @@ public class Factory {
     final Translator translator = new Translator();
     translator.setFirstName("Foo");
     translator.setLastName("Bar");
+    translator.setAssured(true);
 
     return translator;
   }

--- a/src/test/java/fi/oph/akt/Factory.java
+++ b/src/test/java/fi/oph/akt/Factory.java
@@ -26,7 +26,7 @@ public class Factory {
     final Translator translator = new Translator();
     translator.setFirstName("Foo");
     translator.setLastName("Bar");
-    translator.setAssured(true);
+    translator.setAssuranceGiven(true);
 
     return translator;
   }

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -232,6 +232,7 @@ class ClerkTranslatorServiceTest {
     final List<String> towns = Arrays.asList(null, "Kaupunki1", "Kaupunki2");
     final List<String> countries = Arrays.asList("Suomi", null, "Maa2");
     final List<String> extraInformations = Arrays.asList(null, "Nimi muutettu", "???");
+    final List<Boolean> assurances = Arrays.asList(true, false, true);
 
     IntStream
       .range(0, 3)
@@ -247,6 +248,7 @@ class ClerkTranslatorServiceTest {
         translator.setTown(towns.get(i));
         translator.setCountry(countries.get(i));
         translator.setExtraInformation(extraInformations.get(i));
+        translator.setAssured(assurances.get(i));
 
         final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
 
@@ -258,19 +260,22 @@ class ClerkTranslatorServiceTest {
     final List<ClerkTranslatorDTO> translators = responseDTO.translators();
 
     assertEquals(3, translators.size());
-    assertTranslatorField(firstNames, translators, ClerkTranslatorDTO::firstName);
-    assertTranslatorField(lastNames, translators, ClerkTranslatorDTO::lastName);
-    assertTranslatorField(identityNumbers, translators, ClerkTranslatorDTO::identityNumber);
-    assertTranslatorField(emails, translators, ClerkTranslatorDTO::email);
-    assertTranslatorField(phoneNumbers, translators, ClerkTranslatorDTO::phoneNumber);
-    assertTranslatorField(streets, translators, ClerkTranslatorDTO::street);
-    assertTranslatorField(postalCodes, translators, ClerkTranslatorDTO::postalCode);
-    assertTranslatorField(towns, translators, ClerkTranslatorDTO::town);
-    assertTranslatorField(countries, translators, ClerkTranslatorDTO::country);
-    assertTranslatorField(extraInformations, translators, ClerkTranslatorDTO::extraInformation);
+
+    assertTranslatorTextField(firstNames, translators, ClerkTranslatorDTO::firstName);
+    assertTranslatorTextField(lastNames, translators, ClerkTranslatorDTO::lastName);
+    assertTranslatorTextField(identityNumbers, translators, ClerkTranslatorDTO::identityNumber);
+    assertTranslatorTextField(emails, translators, ClerkTranslatorDTO::email);
+    assertTranslatorTextField(phoneNumbers, translators, ClerkTranslatorDTO::phoneNumber);
+    assertTranslatorTextField(streets, translators, ClerkTranslatorDTO::street);
+    assertTranslatorTextField(postalCodes, translators, ClerkTranslatorDTO::postalCode);
+    assertTranslatorTextField(towns, translators, ClerkTranslatorDTO::town);
+    assertTranslatorTextField(countries, translators, ClerkTranslatorDTO::country);
+    assertTranslatorTextField(extraInformations, translators, ClerkTranslatorDTO::extraInformation);
+
+    assertEquals(assurances, translators.stream().map(ClerkTranslatorDTO::isAssured).toList());
   }
 
-  private void assertTranslatorField(
+  private void assertTranslatorTextField(
     final List<String> expected,
     final List<ClerkTranslatorDTO> translators,
     final Function<ClerkTranslatorDTO, String> getter
@@ -498,6 +503,8 @@ class ClerkTranslatorServiceTest {
       .town("tw")
       .postalCode("pstl")
       .country("ct")
+      .extraInformation("extra")
+      .isAssured(true)
       .authorisations(List.of(expectedAuth))
       .build();
 
@@ -557,6 +564,8 @@ class ClerkTranslatorServiceTest {
       .town("tw")
       .postalCode("pstl")
       .country("ct")
+      .extraInformation("extra")
+      .isAssured(false)
       .build();
 
     final ClerkTranslatorDTO response = clerkTranslatorService.updateTranslator(updateDTO);
@@ -582,6 +591,7 @@ class ClerkTranslatorServiceTest {
     assertEquals(expected.postalCode(), dto.postalCode());
     assertEquals(expected.country(), dto.country());
     assertEquals(expected.extraInformation(), dto.extraInformation());
+    assertEquals(expected.isAssured(), dto.isAssured());
   }
 
   @Test

--- a/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/ClerkTranslatorServiceTest.java
@@ -248,7 +248,7 @@ class ClerkTranslatorServiceTest {
         translator.setTown(towns.get(i));
         translator.setCountry(countries.get(i));
         translator.setExtraInformation(extraInformations.get(i));
-        translator.setAssured(assurances.get(i));
+        translator.setAssuranceGiven(assurances.get(i));
 
         final Authorisation authorisation = Factory.authorisation(translator, meetingDate);
 
@@ -272,7 +272,7 @@ class ClerkTranslatorServiceTest {
     assertTranslatorTextField(countries, translators, ClerkTranslatorDTO::country);
     assertTranslatorTextField(extraInformations, translators, ClerkTranslatorDTO::extraInformation);
 
-    assertEquals(assurances, translators.stream().map(ClerkTranslatorDTO::isAssured).toList());
+    assertEquals(assurances, translators.stream().map(ClerkTranslatorDTO::isAssuranceGiven).toList());
   }
 
   private void assertTranslatorTextField(
@@ -504,7 +504,7 @@ class ClerkTranslatorServiceTest {
       .postalCode("pstl")
       .country("ct")
       .extraInformation("extra")
-      .isAssured(true)
+      .isAssuranceGiven(true)
       .authorisations(List.of(expectedAuth))
       .build();
 
@@ -565,7 +565,7 @@ class ClerkTranslatorServiceTest {
       .postalCode("pstl")
       .country("ct")
       .extraInformation("extra")
-      .isAssured(false)
+      .isAssuranceGiven(false)
       .build();
 
     final ClerkTranslatorDTO response = clerkTranslatorService.updateTranslator(updateDTO);
@@ -591,7 +591,7 @@ class ClerkTranslatorServiceTest {
     assertEquals(expected.postalCode(), dto.postalCode());
     assertEquals(expected.country(), dto.country());
     assertEquals(expected.extraInformation(), dto.extraInformation());
-    assertEquals(expected.isAssured(), dto.isAssured());
+    assertEquals(expected.isAssuranceGiven(), dto.isAssuranceGiven());
   }
 
   @Test

--- a/src/test/java/fi/oph/akt/service/PublicTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/PublicTranslatorServiceTest.java
@@ -190,7 +190,7 @@ class PublicTranslatorServiceTest {
     final LocalDate termBeginDate,
     final LocalDate termEndDate,
     final boolean permissionToPublish,
-    final boolean isAssured,
+    final boolean isAssuranceGiven,
     final int i
   ) {
     final Translator translator = Factory.translator();
@@ -198,7 +198,7 @@ class PublicTranslatorServiceTest {
     translator.setLastName("Suku" + i);
     translator.setTown("Kaupunki" + i);
     translator.setCountry("Maa" + i);
-    translator.setAssured(isAssured);
+    translator.setAssuranceGiven(isAssuranceGiven);
 
     entityManager.persist(translator);
     createAuthorisation(translator, meetingDate, termBeginDate, termEndDate, permissionToPublish, "EN");

--- a/src/test/java/fi/oph/akt/service/PublicTranslatorServiceTest.java
+++ b/src/test/java/fi/oph/akt/service/PublicTranslatorServiceTest.java
@@ -161,25 +161,28 @@ class PublicTranslatorServiceTest {
   private void createVariousTranslators(final MeetingDate meetingDate) {
     int i = 0;
     // Term active
-    createTranslator(meetingDate, LocalDate.now(), LocalDate.now().plusDays(1), true, i++);
+    createTranslator(meetingDate, LocalDate.now(), LocalDate.now().plusDays(1), true, true, i++);
 
     // Term active
-    createTranslator(meetingDate, LocalDate.now().minusDays(1), LocalDate.now(), true, i++);
+    createTranslator(meetingDate, LocalDate.now().minusDays(1), LocalDate.now(), true, true, i++);
 
     // Term active (no end date)
-    createTranslator(meetingDate, LocalDate.now(), null, true, i++);
+    createTranslator(meetingDate, LocalDate.now(), null, true, true, i++);
 
     // Term active but no permission given
-    createTranslator(meetingDate, LocalDate.now().minusDays(10), LocalDate.now().plusDays(10), false, i++);
+    createTranslator(meetingDate, LocalDate.now().minusDays(10), LocalDate.now().plusDays(10), false, true, i++);
+
+    // Term active, but not assured
+    createTranslator(meetingDate, LocalDate.now().minusDays(10), LocalDate.now().plusDays(10), true, false, i++);
 
     // Term ended
-    createTranslator(meetingDate, LocalDate.now().minusDays(10), LocalDate.now().minusDays(1), true, i++);
+    createTranslator(meetingDate, LocalDate.now().minusDays(10), LocalDate.now().minusDays(1), true, true, i++);
 
     // Term in future
-    createTranslator(meetingDate, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), true, i++);
+    createTranslator(meetingDate, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), true, true, i++);
 
     // Term in future (no end date)
-    createTranslator(meetingDate, LocalDate.now().plusDays(1), null, true, i++);
+    createTranslator(meetingDate, LocalDate.now().plusDays(1), null, true, true, i);
   }
 
   private void createTranslator(
@@ -187,6 +190,7 @@ class PublicTranslatorServiceTest {
     final LocalDate termBeginDate,
     final LocalDate termEndDate,
     final boolean permissionToPublish,
+    final boolean isAssured,
     final int i
   ) {
     final Translator translator = Factory.translator();
@@ -194,6 +198,7 @@ class PublicTranslatorServiceTest {
     translator.setLastName("Suku" + i);
     translator.setTown("Kaupunki" + i);
     translator.setCountry("Maa" + i);
+    translator.setAssured(isAssured);
 
     entityManager.persist(translator);
     createAuthorisation(translator, meetingDate, termBeginDate, termEndDate, permissionToPublish, "EN");


### PR DESCRIPTION
Lisätty sarake `is_assured` kääntäjille. Jos kääntäjä ei ole antanut vakuutusta, ei hänen auktorisointejaan listata julkisesti. Vakuutusta ei voi tämän yhteydessä vielä UI:sta käsin tarkastella tai muuttaa, mutta backendin muokkaustoiminnallisuus löytyy jo kääntäjän tietoja talletettaessa.

Sellaista pohdin, että olisiko virkailijan kääntäjien listaussivulla hyvä, että "Julkaistu" sarake näyttäisi auktorisointia kohti tiedon, onko ko. auktorisointi julkisessa UI:ssa nähtävillä sen sijaan, että näkyisi vain, onko auktorisointi merkattu julkaistavaksi vaikka vakuutusta ei olisikaan vielä annettu. Tuolle en toistaiseksi tehnyt mitään.

Tehty taskin KEH-266 päälle.