### PR TITLE
OPHAKTKEH-274: kokouspäiväsivun parannukset

### DIFF
--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -168,8 +168,36 @@
           "updateFailed": "Tietojen tallennus epäonnistui"
         }
       },
+      "meetingDatesToggleFilters": {
+        "upcoming": "Tulevat",
+        "passed": "Menneet"
+      },
+      "addMeetingDate": {
+        "header": "Lisää kokouspäivä",
+        "datePicker": {
+          "label": "Kokouspäivämäärä"
+        },
+        "buttons": {
+          "add": "Lisää kokouspäivä"
+        },
+        "toasts": {
+          "error": "Kokouspäivän lisäys epäonnistui"
+        }
+      },
       "meetingDatesListing": {
-        "header": "Kokouspäivä"
+        "header": "Kokouspäivä",
+        "row": {
+          "removal": {
+            "ariaLabel": "Poista kokouspäivä",
+            "dialog": {
+              "header": "Haluatko varmasti poistaa kokouspäivän?",
+              "description": "Tätä toimintoa ei voi peruuttaa!"
+            },
+            "toasts": {
+              "error": "Kokouspäivän poisto epäonnistui"
+            }
+          }
+        }
       },
       "contactRequestForm": {
         "title": "Yhteydenottopyynnön jättäminen",
@@ -267,30 +295,7 @@
         "town": "Asuinkunta"
       },
       "meetingDatesPage": {
-        "title": "Kokouspäivät",
-        "upcoming": "Tulevat",
-        "passed": "Menneet",
-        "removeMeetingDate": {
-          "dialogHeader": "Haluatko varmasti poistaa kokouspäivän?",
-          "dialogDescription": "Tätä toimintoa ei voi peruuttaa!",
-          "toast": {
-            "error": "Kokouspäivän lisäys epäonnistui, yritä myöhemmin uudelleen."
-          },
-          "removeButtonAriaLabel": "Poista kokouspäivä"
-        },
-        "addMeetingDate": {
-          "header": "Lisää kokouspäivä",
-          "datePicker": {
-            "label": "Kokouspäivämäärä",
-            "placeholder": "pp.kk.vvvv"
-          },
-          "button": {
-            "add": "Lisää kokouspäivä"
-          },
-          "toast": {
-            "error": "Kokouspäivän lisäys epäonnistui, yritä myöhemmin uudelleen."
-          }
-        }
+        "title": "Kokouspäivät"
       },
       "notFoundPage": {
         "title": "Valitettavasti etsimääsi sivua ei löytynyt",

--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -191,7 +191,7 @@
             "ariaLabel": "Poista kokouspäivä",
             "dialog": {
               "header": "Haluatko varmasti poistaa kokouspäivän?",
-              "description": "Tätä toimintoa ei voi peruuttaa!"
+              "description": "Kokouspäivän poisto on mahdollista, jos siihen ei liity yhtään auktorisointia."
             },
             "toasts": {
               "error": "Kokouspäivän poisto epäonnistui"

--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -97,7 +97,7 @@
           "valid": "Voimassa",
           "authorisationBeginDate": "Alkamispäivä",
           "authorisationEndDate": "Päättymispäivä",
-          "permissionToPublish": "Julkaistu"
+          "permissionToPublish": "Julkaisulupa"
         },
         "detailsButton": "Lisätiedot"
       },
@@ -106,7 +106,7 @@
           "title": "Peruste",
           "placeholder": "Auktorisointi"
         },
-        "published": {
+        "permissionToPublish": {
           "title": "Julkaisulupa",
           "placeholder": "Kaikki"
         },

--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -280,7 +280,10 @@
         },
         "addMeetingDate": {
           "header": "Lisää kokouspäivä",
-          "datePickerLabel": "Kokouspäivämäärä",
+          "datePicker": {
+            "label": "Kokouspäivämäärä",
+            "placeholder": "pp.kk.vvvv"
+          },
           "button": {
             "add": "Lisää kokouspäivä"
           },

--- a/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
@@ -14,7 +14,7 @@ import {
   useKoodistoLanguagesTranslation,
 } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
-import { TextFieldVariant } from 'enums/app';
+import { PermissionToPublish, TextFieldVariant } from 'enums/app';
 import { useDebouncedValue } from 'hooks/useDebouncedValue';
 import { ClerkTranslatorFilter } from 'interfaces/clerkTranslator';
 import { AutocompleteValue } from 'interfaces/combobox';
@@ -118,7 +118,7 @@ export const ClerkTranslatorAutocompleteFilters = () => {
           autoHighlight
           data-testid="clerk-translator-filters__permission-to-publish-basis"
           label={t('permissionToPublish.placeholder')}
-          values={['Kyllä', 'Ei'].map(valueAsOption)}
+          values={Object.values(PermissionToPublish).map(valueAsOption)}
           value={
             filters.permissionToPublish
               ? valueAsOption(filters.permissionToPublish)

--- a/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
@@ -113,11 +113,11 @@ export const ClerkTranslatorAutocompleteFilters = () => {
         />
       </div>
       <div className="rows gapped-xs">
-        <H3>{t('published.title')}</H3>
+        <H3>{t('permissionToPublish.title')}</H3>
         <ComboBox
           autoHighlight
           data-testid="clerk-translator-filters__permission-to-publish-basis"
-          label={t('published.placeholder')}
+          label={t('permissionToPublish.placeholder')}
           values={['Kyllä', 'Ei'].map(valueAsOption)}
           value={
             filters.permissionToPublish

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
@@ -8,7 +8,7 @@ import { useAppTranslation } from 'configs/i18n';
 import { useAppDispatch, useAppSelector } from 'configs/redux';
 import { Color, Variant } from 'enums/app';
 import { addMeetingDate } from 'redux/actions/meetingDate';
-import { selectMeetingDatesByMeetingStatus } from 'redux/selectors/meetingDate';
+import { meetingDatesSelector } from 'redux/selectors/meetingDate';
 import { DateUtils } from 'utils/date';
 
 export const AddMeetingDate = () => {
@@ -16,7 +16,10 @@ export const AddMeetingDate = () => {
   const { t } = useAppTranslation({
     keyPrefix: 'akt.component.addMeetingDate',
   });
-  const { upcoming } = useAppSelector(selectMeetingDatesByMeetingStatus);
+
+  const {
+    meetingDates: { meetingDates },
+  } = useAppSelector(meetingDatesSelector);
 
   const dispatch = useAppDispatch();
 
@@ -28,8 +31,8 @@ export const AddMeetingDate = () => {
     if (value) {
       const date = new Date(value);
 
-      return upcoming.some((upcomingDate) =>
-        DateUtils.isDatePartEqual(upcomingDate.date, date)
+      return meetingDates.some((meetingDate) =>
+        DateUtils.isDatePartEqual(meetingDate.date, date)
       );
     }
 
@@ -45,6 +48,8 @@ export const AddMeetingDate = () => {
             value={value}
             setValue={setValue}
             label={t('datePicker.label')}
+            minDate={DateUtils.newDate(-365 * 100)}
+            maxDate={DateUtils.newDate(365 * 100)}
           />
           <CustomButton
             data-testid="clerk-translator-overview__authorisation-details__add-btn"

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
@@ -21,38 +21,38 @@ export const AddMeetingDate = () => {
   const dispatch = useAppDispatch();
 
   const handleOnClick = () => {
-    value &&
-      dispatch(addMeetingDate(DateUtils.dateAtStartOfDay(new Date(value))));
+    value && dispatch(addMeetingDate(new Date(value)));
   };
 
-  const shouldDisableAddMeetingDateButton = () => {
-    if (!value) {
-      return true;
-    } else {
-      const date = DateUtils.dateAtStartOfDay(new Date(value));
+  const isAddButtonDisabled = () => {
+    if (value) {
+      const date = new Date(value);
 
-      return upcoming.some(
-        (upcomingDate) => upcomingDate.date.getTime() === date.getTime()
+      return upcoming.some((upcomingDate) =>
+        DateUtils.isDatePartEqual(upcomingDate.date, date)
       );
     }
+
+    return true;
   };
 
   return (
     <div className="columns gapped">
-      <div className="rows gapped-xs flex-grow-3">
+      <div className="rows gapped flex-grow-3">
         <H3>{t('header')}</H3>
         <div className="columns gapped">
           <DatePicker
             value={value}
             setValue={setValue}
-            label={t('datePickerLabel')}
+            label={t('datePicker.label')}
+            placeholder={t('datePicker.placeholder')}
           />
           <CustomButton
             data-testid="clerk-translator-overview__authorisation-details__add-btn"
             variant={Variant.Outlined}
             color={Color.Secondary}
             startIcon={<AddIcon />}
-            disabled={shouldDisableAddMeetingDateButton()}
+            disabled={isAddButtonDisabled()}
             onClick={handleOnClick}
           >
             {t('button.add')}

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/AddMeetingDate.tsx
@@ -14,7 +14,7 @@ import { DateUtils } from 'utils/date';
 export const AddMeetingDate = () => {
   const [value, setValue] = useState<string>('');
   const { t } = useAppTranslation({
-    keyPrefix: 'akt.pages.meetingDatesPage.addMeetingDate',
+    keyPrefix: 'akt.component.addMeetingDate',
   });
   const { upcoming } = useAppSelector(selectMeetingDatesByMeetingStatus);
 
@@ -45,7 +45,6 @@ export const AddMeetingDate = () => {
             value={value}
             setValue={setValue}
             label={t('datePicker.label')}
-            placeholder={t('datePicker.placeholder')}
           />
           <CustomButton
             data-testid="clerk-translator-overview__authorisation-details__add-btn"
@@ -55,7 +54,7 @@ export const AddMeetingDate = () => {
             disabled={isAddButtonDisabled()}
             onClick={handleOnClick}
           >
-            {t('button.add')}
+            {t('buttons.add')}
           </CustomButton>
         </div>
       </div>

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -39,7 +39,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
   const dispatchConfirmRemoveNotifier = () => {
     const notifier = Utils.createNotifierDialog(
       t('dialogHeader'),
-      Severity.Error,
+      Severity.Info,
       t('dialogDescription'),
       [
         {

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -49,7 +49,6 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
           title: translateCommon('yes'),
           variant: Variant.Contained,
           action: () => dispatch(removeMeetingDate(meetingDate.id)),
-          buttonColor: Color.Error,
         },
       ]
     );

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -28,9 +28,7 @@ const getRowDetails = (meetingDate: MeetingDate) => {
 
 const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
   const dispatch = useAppDispatch();
-  const {
-    meetingDates: { filters },
-  } = useAppSelector(meetingDatesSelector);
+
   const { t } = useAppTranslation({
     keyPrefix: 'akt.component.meetingDatesListing.row.removal',
   });
@@ -66,17 +64,15 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
       <TableCell>
         <Text>{formattedDate}</Text>
       </TableCell>
-      {filters.meetingStatus === MeetingStatus.Upcoming && (
-        <TableCell align="right">
-          <CustomIconButton
-            data-testid="meeting-dates-page__add-button"
-            onClick={dispatchConfirmRemoveNotifier}
-            aria-label={`${t('ariaLabel')} ${formattedDate}`}
-          >
-            <DeleteIcon color={Color.Error} />
-          </CustomIconButton>
-        </TableCell>
-      )}
+      <TableCell align="right">
+        <CustomIconButton
+          data-testid="meeting-dates-page__add-button"
+          onClick={dispatchConfirmRemoveNotifier}
+          aria-label={`${t('ariaLabel')} ${formattedDate}`}
+        >
+          <DeleteIcon color={Color.Error} />
+        </CustomIconButton>
+      </TableCell>
     </TableRow>
   );
 };
@@ -86,9 +82,6 @@ const ListingHeader: FC = () => {
     keyPrefix: 'akt.component.meetingDatesListing',
   });
   const translateCommon = useCommonTranslation();
-  const {
-    meetingDates: { filters },
-  } = useAppSelector(meetingDatesSelector);
 
   return (
     <TableHead>
@@ -96,11 +89,9 @@ const ListingHeader: FC = () => {
         <TableCell>
           <H3>{t('header')}</H3>
         </TableCell>
-        {filters.meetingStatus === MeetingStatus.Upcoming && (
-          <TableCell align="right">
-            <H3>{translateCommon('delete')}</H3>
-          </TableCell>
-        )}
+        <TableCell align="right">
+          <H3>{translateCommon('delete')}</H3>
+        </TableCell>
       </TableRow>
     </TableHead>
   );

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesListing.tsx
@@ -32,15 +32,15 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
     meetingDates: { filters },
   } = useAppSelector(meetingDatesSelector);
   const { t } = useAppTranslation({
-    keyPrefix: 'akt.pages.meetingDatesPage.removeMeetingDate',
+    keyPrefix: 'akt.component.meetingDatesListing.row.removal',
   });
   const translateCommon = useCommonTranslation();
 
   const dispatchConfirmRemoveNotifier = () => {
     const notifier = Utils.createNotifierDialog(
-      t('dialogHeader'),
+      t('dialog.header'),
       Severity.Info,
-      t('dialogDescription'),
+      t('dialog.description'),
       [
         {
           title: translateCommon('back'),
@@ -71,7 +71,7 @@ const ListingRow = ({ meetingDate }: { meetingDate: MeetingDate }) => {
           <CustomIconButton
             data-testid="meeting-dates-page__add-button"
             onClick={dispatchConfirmRemoveNotifier}
-            aria-label={`${t('removeButtonAriaLabel')} ${formattedDate}`}
+            aria-label={`${t('ariaLabel')} ${formattedDate}`}
           >
             <DeleteIcon color={Color.Error} />
           </CustomIconButton>

--- a/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesToggleFilters.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/meetingDates/MeetingDatesToggleFilters.tsx
@@ -10,7 +10,7 @@ import {
 
 export const MeetingDatesToggleFilters = () => {
   const { t } = useAppTranslation({
-    keyPrefix: 'akt.pages.meetingDatesPage',
+    keyPrefix: 'akt.component.meetingDatesToggleFilters',
   });
 
   const { upcoming, passed } = useAppSelector(

--- a/src/main/reactjs/src/components/elements/DatePicker.tsx
+++ b/src/main/reactjs/src/components/elements/DatePicker.tsx
@@ -9,7 +9,6 @@ export const DatePicker = ({
   value,
   setValue,
   label,
-  placeholder,
 }: DatePickerProps): JSX.Element => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -19,7 +18,6 @@ export const DatePicker = ({
     <Stack spacing={3}>
       <TextField
         label={label}
-        placeholder={placeholder}
         type="date"
         onChange={handleChange}
         value={value}

--- a/src/main/reactjs/src/components/elements/DatePicker.tsx
+++ b/src/main/reactjs/src/components/elements/DatePicker.tsx
@@ -3,12 +3,12 @@ import TextField from '@mui/material/TextField';
 
 import { DatePickerProps } from 'interfaces/datePicker';
 
-const MAX_DATE = '2222-02-22';
-
 export const DatePicker = ({
   value,
   setValue,
   label,
+  minDate,
+  maxDate,
 }: DatePickerProps): JSX.Element => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -26,8 +26,8 @@ export const DatePicker = ({
           shrink: true,
         }}
         inputProps={{
-          min: new Date().toISOString().split('T')[0],
-          max: MAX_DATE,
+          min: minDate.toISOString().split('T')[0],
+          max: maxDate.toISOString().split('T')[0],
         }}
       />
     </Stack>

--- a/src/main/reactjs/src/components/elements/DatePicker.tsx
+++ b/src/main/reactjs/src/components/elements/DatePicker.tsx
@@ -2,7 +2,6 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 
 import { DatePickerProps } from 'interfaces/datePicker';
-import { DateUtils } from 'utils/date';
 
 const MAX_DATE = '2222-02-22';
 
@@ -10,6 +9,7 @@ export const DatePicker = ({
   value,
   setValue,
   label,
+  placeholder,
 }: DatePickerProps): JSX.Element => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -19,6 +19,7 @@ export const DatePicker = ({
     <Stack spacing={3}>
       <TextField
         label={label}
+        placeholder={placeholder}
         type="date"
         onChange={handleChange}
         value={value}
@@ -27,10 +28,8 @@ export const DatePicker = ({
           shrink: true,
         }}
         inputProps={{
+          min: new Date().toISOString().split('T')[0],
           max: MAX_DATE,
-          min: DateUtils.dateAtStartOfDay(new Date())
-            .toISOString()
-            .split('T')[0],
         }}
       />
     </Stack>

--- a/src/main/reactjs/src/interfaces/datePicker.ts
+++ b/src/main/reactjs/src/interfaces/datePicker.ts
@@ -2,4 +2,5 @@ export interface DatePickerProps {
   value: string;
   setValue: (value: string) => void;
   label: string;
+  placeholder: string;
 }

--- a/src/main/reactjs/src/interfaces/datePicker.ts
+++ b/src/main/reactjs/src/interfaces/datePicker.ts
@@ -2,5 +2,4 @@ export interface DatePickerProps {
   value: string;
   setValue: (value: string) => void;
   label: string;
-  placeholder: string;
 }

--- a/src/main/reactjs/src/interfaces/datePicker.ts
+++ b/src/main/reactjs/src/interfaces/datePicker.ts
@@ -2,4 +2,6 @@ export interface DatePickerProps {
   value: string;
   setValue: (value: string) => void;
   label: string;
+  minDate: Date;
+  maxDate: Date;
 }

--- a/src/main/reactjs/src/redux/reducers/meetingDate.ts
+++ b/src/main/reactjs/src/redux/reducers/meetingDate.ts
@@ -20,7 +20,6 @@ import {
   MEETING_DATE_REMOVE_ERROR,
   MEETING_DATE_REMOVE_SUCCESS,
 } from 'redux/actionTypes/meetingDate';
-import { DateUtils } from 'utils/date';
 
 const defaultState = {
   meetingDates: {
@@ -32,7 +31,7 @@ const defaultState = {
   },
   addMeetingDate: {
     status: APIResponseStatus.NotStarted,
-    date: DateUtils.dateAtStartOfDay(new Date()),
+    date: new Date(),
   },
   removeMeetingDate: {
     status: APIResponseStatus.NotStarted,

--- a/src/main/reactjs/src/redux/sagas/meetingDate.ts
+++ b/src/main/reactjs/src/redux/sagas/meetingDate.ts
@@ -27,11 +27,11 @@ import { NOTIFIER_TOAST_ADD } from 'redux/actionTypes/notifier';
 import { Utils } from 'utils';
 import { APIUtils } from 'utils/api';
 
-function* showErrorToastonRemove() {
+function* showErrorToastOnRemove() {
   const t = translateOutsideComponent();
   const notifier = Utils.createNotifierToast(
     Severity.Error,
-    t('akt.pages.meetingDatesPage.removeMeetingDate.toast.error')
+    t('akt.component.meetingDatesListing.row.removal.toasts.error')
   );
   yield put({ type: NOTIFIER_TOAST_ADD, notifier });
 }
@@ -46,14 +46,14 @@ export function* removeMeetingDate(action: RemoveMeetingDateActionType) {
     yield put({ type: MEETING_DATE_LOAD });
   } catch (error) {
     yield put({ type: MEETING_DATE_REMOVE_ERROR });
-    yield call(showErrorToastonRemove);
+    yield call(showErrorToastOnRemove);
   }
 }
 function* showErrorToastOnAdd() {
   const t = translateOutsideComponent();
   const notifier = Utils.createNotifierToast(
     Severity.Error,
-    t('akt.pages.meetingDatesPage.addMeetingDate.toast.error')
+    t('akt.component.addMeetingDate.toasts.error')
   );
   yield put({ type: NOTIFIER_TOAST_ADD, notifier });
 }

--- a/src/main/reactjs/src/redux/selectors/meetingDate.ts
+++ b/src/main/reactjs/src/redux/selectors/meetingDate.ts
@@ -17,13 +17,13 @@ export const selectMeetingDatesByMeetingStatus = createSelector(
       .filter(({ date }) =>
         filterMeetingDateByStatus(date, MeetingStatus.Upcoming, currentDate)
       )
-      .sort((a, b) => a.date - b.date);
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
 
     const passed = meetingDates.meetingDates
       .filter(({ date }) =>
         filterMeetingDateByStatus(date, MeetingStatus.Passed, currentDate)
       )
-      .sort((a, b) => b.date - a.date);
+      .sort((a, b) => b.date.getTime() - a.date.getTime());
 
     return {
       upcoming,

--- a/src/main/reactjs/src/redux/selectors/meetingDate.ts
+++ b/src/main/reactjs/src/redux/selectors/meetingDate.ts
@@ -12,13 +12,18 @@ export const selectMeetingDatesByMeetingStatus = createSelector(
     // TODO Note that this has an *implicit* dependency on the current system time,
     // which we currently fail to take into account properly - the selectors should
     // somehow make the dependency on time explicit!
-    const currentDate = DateUtils.dateAtStartOfDay(new Date());
-    const upcoming = meetingDates.meetingDates.filter(({ date }) =>
-      filterMeetingDatesByStatus(date, MeetingStatus.Upcoming, currentDate)
-    );
-    const passed = meetingDates.meetingDates.filter(({ date }) =>
-      filterMeetingDatesByStatus(date, MeetingStatus.Passed, currentDate)
-    );
+    const currentDate = new Date();
+    const upcoming = meetingDates.meetingDates
+      .filter(({ date }) =>
+        filterMeetingDateByStatus(date, MeetingStatus.Upcoming, currentDate)
+      )
+      .sort((a, b) => a.date - b.date);
+
+    const passed = meetingDates.meetingDates
+      .filter(({ date }) =>
+        filterMeetingDateByStatus(date, MeetingStatus.Passed, currentDate)
+      )
+      .sort((a, b) => b.date - a.date);
 
     return {
       upcoming,
@@ -27,14 +32,12 @@ export const selectMeetingDatesByMeetingStatus = createSelector(
   }
 );
 
-const filterMeetingDatesByStatus = (
+const filterMeetingDateByStatus = (
   date: Date,
   status: MeetingStatus,
   currentDate: Date
 ) => {
-  if (status === MeetingStatus.Upcoming) {
-    return !DateUtils.isDatePartBeforeOrEqual(date, currentDate);
-  }
+  const isBefore = DateUtils.isDatePartBefore(date, currentDate);
 
-  return DateUtils.isDatePartBeforeOrEqual(date, currentDate);
+  return status === MeetingStatus.Upcoming ? !isBefore : isBefore;
 };

--- a/src/main/reactjs/src/styles/styles.scss
+++ b/src/main/reactjs/src/styles/styles.scss
@@ -16,10 +16,10 @@
 // Components
 @import 'components/clerkTranslator/authorisation-details';
 @import 'components/clerkTranslator/clerk-translator-autocomplete-filters';
-@import 'components/elements/custom-circular-progress';
-@import 'components/elements/custom-button-link';
-@import 'components/elements/header-separator';
 @import 'components/elements/circular-stepper';
+@import 'components/elements/custom-button-link';
+@import 'components/elements/custom-circular-progress';
+@import 'components/elements/header-separator';
 @import 'components/elements/skip-link';
 @import 'components/i18n/lang-selector';
 @import 'components/layouts/header';

--- a/src/main/reactjs/src/utils/date.ts
+++ b/src/main/reactjs/src/utils/date.ts
@@ -8,6 +8,13 @@ const getDateTimeFormatter = (lang: AppLanguage) => {
 };
 
 export class DateUtils {
+  static newDate(dateChange: number) {
+    const date = new Date();
+    date.setDate(date.getDate() + dateChange);
+
+    return date;
+  }
+
   static formatOptionalDate(date?: Date) {
     if (!date) {
       return '-';

--- a/src/main/reactjs/src/utils/date.ts
+++ b/src/main/reactjs/src/utils/date.ts
@@ -37,7 +37,7 @@ export class DateUtils {
     );
   }
 
-  static isDatePartBeforeOrEqual(before: Date, after: Date) {
+  static isDatePartBefore(before: Date, after: Date) {
     // Compare years
     if (before.getFullYear() < after.getFullYear()) {
       return true;
@@ -52,6 +52,21 @@ export class DateUtils {
     }
 
     // Equal months, finally compare dates
-    return before.getDate() <= after.getDate();
+    return before.getDate() < after.getDate();
+  }
+
+  static isDatePartEqual(before: Date, after: Date) {
+    return (
+      before.getFullYear() === after.getFullYear() &&
+      before.getMonth() === after.getMonth() &&
+      before.getDate() === after.getDate()
+    );
+  }
+
+  static isDatePartBeforeOrEqual(before: Date, after: Date) {
+    return (
+      this.isDatePartBefore(before, after) ||
+      this.isDatePartEqual(before, after)
+    );
   }
 }


### PR DESCRIPTION
- Päivämäärät talletetaan kuten date pickeristä valittu
- Ei mahdollista valita mennyttä päivämäärää
- Jos tälle päivämäärälle luo kokouspäivän, näkyy se tulevissa ja on yhä poistettavissa
- Kokouspäivät listataan tulevissa tulevasta kaukaisimpaan, kun taas menneissä tuoreimmasta vanhimpaan
- Lisätty paddingiä ylle kuten tiketissä kuvattu
- Kokouspäivän poistossa Severity.Info väri

Placeholderin teksti ei toistaiseksi näy, kun en saanut sitä pellittämään. Datepickerin tekstin väri jo vakiostaan nähdäkseni suunniteltu #666 ja en määrittänyt sitä enää erikseen. Lisäksi tähän voisi ehkä kirjoittaa testejä.