### PR TITLE
OPHAKTKEH-280: no validation for email in backend

### DIFF
--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
@@ -1,7 +1,6 @@
 package fi.oph.akt.api.dto.clerk.modify;
 
 import java.util.List;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import lombok.Builder;
@@ -11,7 +10,7 @@ public record TranslatorCreateDTO(
   @NonNull @NotBlank String firstName,
   @NonNull @NotBlank String lastName,
   String identityNumber,
-  @Email String email,
+  String email,
   String phoneNumber,
   String street,
   String postalCode,

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
@@ -1,6 +1,5 @@
 package fi.oph.akt.api.dto.clerk.modify;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -12,7 +11,7 @@ public record TranslatorUpdateDTO(
   @NonNull @NotBlank String firstName,
   @NonNull @NotBlank String lastName,
   String identityNumber,
-  @Email String email,
+  String email,
   String phoneNumber,
   String street,
   String postalCode,

--- a/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
@@ -1,7 +1,6 @@
 package fi.oph.akt.api.dto.translator;
 
 import java.util.List;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
@@ -9,7 +8,7 @@ import lombok.Builder;
 public record ContactRequestDTO(
   @NotEmpty @Size(max = 255) String firstName,
   @NotEmpty @Size(max = 255) String lastName,
-  @NotEmpty @Email String email,
+  @NotEmpty @Size(max = 255) String email,
   @Size(max = 255) String phoneNumber,
   @NotEmpty @Size(max = 6000) String message,
   @NotEmpty @Size(max = 10) String fromLang,

--- a/src/test/java/fi/oph/akt/api/translator/TranslatorControllerTest.java
+++ b/src/test/java/fi/oph/akt/api/translator/TranslatorControllerTest.java
@@ -83,9 +83,17 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithInvalidEmail() throws Exception {
+  public void testContactRequestWithEmptyEmail() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("email", "foo2bar");
+    data.put("email", "");
+
+    postContactRequest(data).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void testContactRequestWithTooLongEmail() throws Exception {
+    final JSONObject data = validContactRequestData();
+    data.put("email", "x".repeat(256));
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }


### PR DESCRIPTION
Halutessa voidaan yhteydenottopyyntöä varten siirtää frontin email validaatio `EMAIL_REG_EXR = /^.+@.+\..+$/` bäkkärin puolelle ja validoida yhteydenottopyynnössä jätetty sähköpostiosoite ContactRequestServicessä. Kääntäjän tietojen tallennusta varten validointi ei ole parhaillaan mielekästä, sillä frontend sallii epävalidin mailiosoitteen tallentamisen.