### PR TITLE
OPHAKTKEH-205: proper scheduling times

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Required packages get installed automatically.
 
 ### Authentication and Authorisation
 
-### Production Profile
+#### Production Profile
 
 CAS configurations are used by default.
 
 &nbsp;
 
-### Development Profile
+#### Development Profile
 
 Dev profile configurations are used by default.
 
@@ -96,6 +96,14 @@ In order to disable Spring Boot Security use property:
 Or
 
 Set `AKT_UNSECURE=true` environment variable as shown [here](#development).
+
+&nbsp;
+
+### Scheduled tasks
+
+`EmailScheduledSending` does scheduling of sending unsent emails. Every 10 seconds (`FIXED_DELAY`) it fetches a batch of at most 10 unsent emails (`BATCH_SIZE`), and tries to send them. If there are loads of emails in the queue, it may send at max. 3600 emails in an hour.
+
+`ExpiringAuthorisationsEmailCreator` does scheduling of finding expiring authorisations, and creating reminder emails about them. It is run every 12 hours (`FIXED_DELAY`). The reminder emails that are created are eventually sent via `EmailScheduledSending`.
 
 &nbsp;
 

--- a/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
@@ -26,7 +26,7 @@ public class EmailScheduledSending {
 
   private static final String LOCK_AT_MOST = "PT2H";
 
-  public static final int BATCH_SIZE = 10; // TODO: should this be bigger?
+  public static final int BATCH_SIZE = 10;
 
   @Resource
   private final EmailRepository emailRepository;

--- a/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
@@ -22,9 +22,9 @@ public class EmailScheduledSending {
 
   private static final String FIXED_DELAY = "PT10S";
 
-  private static final String LOCK_AT_LEAST = "PT10S";
+  private static final String LOCK_AT_LEAST = "PT0S";
 
-  private static final String LOCK_AT_MOST = "PT2H";
+  private static final String LOCK_AT_MOST = "PT1M";
 
   public static final int BATCH_SIZE = 10;
 

--- a/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
+++ b/src/main/java/fi/oph/akt/service/email/EmailScheduledSending.java
@@ -18,15 +18,15 @@ public class EmailScheduledSending {
 
   private static final Logger LOG = LoggerFactory.getLogger(EmailScheduledSending.class);
 
-  private static final String FIXED_DELAY = "PT10S";
-
   private static final String INITIAL_DELAY = "PT10S";
+
+  private static final String FIXED_DELAY = "PT10S";
 
   private static final String LOCK_AT_LEAST = "PT10S";
 
   private static final String LOCK_AT_MOST = "PT2H";
 
-  public static final int BATCH_SIZE = 10;
+  public static final int BATCH_SIZE = 10; // TODO: should this be bigger?
 
   @Resource
   private final EmailRepository emailRepository;
@@ -34,7 +34,7 @@ public class EmailScheduledSending {
   @Resource
   private final EmailService emailService;
 
-  @Scheduled(fixedDelayString = FIXED_DELAY, initialDelayString = INITIAL_DELAY)
+  @Scheduled(initialDelayString = INITIAL_DELAY, fixedDelayString = FIXED_DELAY)
   @SchedulerLock(name = "pollEmailsToSend", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
   public void pollEmailsToSend() {
     SchedulingUtil.runWithScheduledUser(() -> {

--- a/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
+++ b/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
@@ -22,9 +22,9 @@ public class ExpiringAuthorisationsEmailCreator {
 
   private static final String FIXED_DELAY = "PT12H";
 
-  private static final String LOCK_AT_LEAST = "PT10S";
+  private static final String LOCK_AT_LEAST = "PT0S";
 
-  private static final String LOCK_AT_MOST = "PT2H";
+  private static final String LOCK_AT_MOST = "PT1H";
 
   @Resource
   private final AuthorisationRepository authorisationRepository;

--- a/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
+++ b/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
@@ -18,9 +18,9 @@ public class ExpiringAuthorisationsEmailCreator {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExpiringAuthorisationsEmailCreator.class);
 
-  private static final String FIXED_DELAY = "PT1M"; // TODO: change to "PT12H"
+  private static final String INITIAL_DELAY = "PT5S";
 
-  private static final String INITIAL_DELAY = "PT1S"; // TODO: change to "PT1H"
+  private static final String FIXED_DELAY = "PT6H";
 
   private static final String LOCK_AT_LEAST = "PT10S";
 
@@ -32,11 +32,11 @@ public class ExpiringAuthorisationsEmailCreator {
   @Resource
   private final ClerkEmailService clerkEmailService;
 
-  @Scheduled(fixedDelayString = FIXED_DELAY, initialDelayString = INITIAL_DELAY)
-  @SchedulerLock(name = "pollExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
-  public void pollExpiringAuthorisations() {
+  @Scheduled(initialDelayString = INITIAL_DELAY, fixedDelayString = FIXED_DELAY)
+  @SchedulerLock(name = "checkExpiringAuthorisations", lockAtLeastFor = LOCK_AT_LEAST, lockAtMostFor = LOCK_AT_MOST)
+  public void checkExpiringAuthorisations() {
     SchedulingUtil.runWithScheduledUser(() -> {
-      LOG.debug("pollExpiringAuthorisations");
+      LOG.debug("checkExpiringAuthorisations");
       final LocalDate expiryBetweenStart = LocalDate.now();
       final LocalDate expiryBetweenEnd = expiryBetweenStart.plusMonths(3);
       final LocalDateTime previousReminderSentBefore = expiryBetweenStart.minusMonths(4).atStartOfDay();

--- a/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
+++ b/src/main/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreator.java
@@ -20,7 +20,7 @@ public class ExpiringAuthorisationsEmailCreator {
 
   private static final String INITIAL_DELAY = "PT5S";
 
-  private static final String FIXED_DELAY = "PT6H";
+  private static final String FIXED_DELAY = "PT12H";
 
   private static final String LOCK_AT_LEAST = "PT10S";
 

--- a/src/test/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreatorTest.java
+++ b/src/test/java/fi/oph/akt/service/email/ExpiringAuthorisationsEmailCreatorTest.java
@@ -50,7 +50,7 @@ public class ExpiringAuthorisationsEmailCreatorTest {
   }
 
   @Test
-  public void testPollExpiringAuthorisations() {
+  public void testCheckExpiringAuthorisations() {
     final LocalDate date = LocalDate.now();
     final MeetingDate meetingDate = Factory.meetingDate(date.minusYears(1));
     entityManager.persist(meetingDate);
@@ -74,7 +74,7 @@ public class ExpiringAuthorisationsEmailCreatorTest {
     createAuthorisationTermReminder(remindedAuth2);
     createAuthorisationTermReminder(remindedAuth2);
 
-    emailCreator.pollExpiringAuthorisations();
+    emailCreator.checkExpiringAuthorisations();
 
     verify(clerkEmailService, times(3)).createAuthorisationExpiryEmail(longCaptor.capture());
 
@@ -88,13 +88,13 @@ public class ExpiringAuthorisationsEmailCreatorTest {
   }
 
   @Test
-  public void testPollExpiringAuthorisationsWithTranslatorWithoutEmailAddress() {
+  public void testCheckExpiringAuthorisationsWithTranslatorWithoutEmailAddress() {
     final MeetingDate meetingDate = Factory.meetingDate(LocalDate.now().minusYears(1));
     entityManager.persist(meetingDate);
 
     createAuthorisation(meetingDate, LocalDate.now().plusDays(10), null);
 
-    emailCreator.pollExpiringAuthorisations();
+    emailCreator.checkExpiringAuthorisations();
 
     verifyNoInteractions(clerkEmailService);
   }


### PR DESCRIPTION
Kun sovellus starttaa, tarkistetaan 5 sek päästä, onko kääntäjiä, joilla auktorisointioikeus umpeutumassa, mutta tästä ei lähetetty vielä sähköpostia. Generoidaan sähköpostit näistä umpeutumisista. Tämän jälkeen tämä tarkastus tehdään ajastetusti 6 tunnin välein (voisi olla varmaan pidempikin väli).

Sovelluksen starttauksesta 10 sek päästä ja tästä aina 10 sek välein tarkistetaan, onko lähetettäviä sähköposteja (edellä generoidut, yhteydenotot ja virkailijoiden UI:sta luomat mailit) ja lähetetään jonossa olevat 10 seuraavaa. Jos jonossa paljon lähteviä maileja tässä kestää aikansa, että ne saadaan lähetettyä. Batch-kokoa / jonosta otettavien määrää voisi ehkä kasvattavaa?