### PR TITLE
OPHAKTKEH-301: tallettavan tiedon trimmaus ja muita parannuksia

### DIFF
--- a/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
@@ -1,13 +1,14 @@
 package fi.oph.akt.api.dto.clerk;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
 
 public record InformalEmailRequestDTO(
-  @NotEmpty @Size(max = 255) String subject,
-  @NotEmpty @Size(max = 6000) String body,
+  @NotBlank @Size(max = 255) String subject,
+  @NotBlank @Size(max = 6000) String body,
   @NotEmpty List<Long> translatorIds
 ) {
   @Builder

--- a/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/InformalEmailRequestDTO.java
@@ -5,11 +5,12 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
+import lombok.NonNull;
 
 public record InformalEmailRequestDTO(
-  @NotBlank @Size(max = 255) String subject,
-  @NotBlank @Size(max = 6000) String body,
-  @NotEmpty List<Long> translatorIds
+  @NonNull @NotBlank @Size(max = 255) String subject,
+  @NonNull @NotBlank @Size(max = 6000) String body,
+  @NonNull @NotEmpty List<Long> translatorIds
 ) {
   @Builder
   public InformalEmailRequestDTO {}

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
@@ -3,12 +3,12 @@ package fi.oph.akt.api.dto.clerk.modify;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.NonNull;
 
 public record TranslatorCreateDTO(
-  @NonNull @NotBlank String firstName,
-  @NonNull @NotBlank String lastName,
+  @NotBlank String firstName,
+  @NotBlank String lastName,
   String identityNumber,
   String email,
   String phoneNumber,
@@ -17,8 +17,8 @@ public record TranslatorCreateDTO(
   String town,
   String country,
   String extraInformation,
-  @NonNull Boolean isAssuranceGiven,
-  @NonNull @NotEmpty List<AuthorisationCreateDTO> authorisations
+  @NotNull Boolean isAssuranceGiven,
+  @NotEmpty List<AuthorisationCreateDTO> authorisations
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorCreateDTO.java
@@ -5,10 +5,11 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.NonNull;
 
 public record TranslatorCreateDTO(
-  @NotBlank String firstName,
-  @NotBlank String lastName,
+  @NonNull @NotBlank String firstName,
+  @NonNull @NotBlank String lastName,
   String identityNumber,
   String email,
   String phoneNumber,
@@ -17,8 +18,8 @@ public record TranslatorCreateDTO(
   String town,
   String country,
   String extraInformation,
-  @NotNull Boolean isAssuranceGiven,
-  @NotEmpty List<AuthorisationCreateDTO> authorisations
+  @NonNull @NotNull Boolean isAssuranceGiven,
+  @NonNull @NotEmpty List<AuthorisationCreateDTO> authorisations
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
@@ -3,12 +3,13 @@ package fi.oph.akt.api.dto.clerk.modify;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.NonNull;
 
 public record TranslatorUpdateDTO(
-  @NotNull Long id,
-  @NotNull Integer version,
-  @NotBlank String firstName,
-  @NotBlank String lastName,
+  @NonNull @NotNull Long id,
+  @NonNull @NotNull Integer version,
+  @NonNull @NotBlank String firstName,
+  @NonNull @NotBlank String lastName,
   String identityNumber,
   String email,
   String phoneNumber,
@@ -17,7 +18,7 @@ public record TranslatorUpdateDTO(
   String town,
   String country,
   String extraInformation,
-  @NotNull Boolean isAssuranceGiven
+  @NonNull @NotNull Boolean isAssuranceGiven
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/clerk/modify/TranslatorUpdateDTO.java
@@ -3,13 +3,12 @@ package fi.oph.akt.api.dto.clerk.modify;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.NonNull;
 
 public record TranslatorUpdateDTO(
-  @NonNull @NotNull Long id,
-  @NonNull @NotNull Integer version,
-  @NonNull @NotBlank String firstName,
-  @NonNull @NotBlank String lastName,
+  @NotNull Long id,
+  @NotNull Integer version,
+  @NotBlank String firstName,
+  @NotBlank String lastName,
   String identityNumber,
   String email,
   String phoneNumber,
@@ -18,7 +17,7 @@ public record TranslatorUpdateDTO(
   String town,
   String country,
   String extraInformation,
-  @NonNull Boolean isAssuranceGiven
+  @NotNull Boolean isAssuranceGiven
 )
   implements TranslatorDTOCommonFields {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
@@ -5,16 +5,17 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
+import lombok.NonNull;
 
 public record ContactRequestDTO(
-  @NotBlank @Size(max = 255) String firstName,
-  @NotBlank @Size(max = 255) String lastName,
-  @NotBlank @Size(max = 255) String email,
+  @NonNull @NotBlank @Size(max = 255) String firstName,
+  @NonNull @NotBlank @Size(max = 255) String lastName,
+  @NonNull @NotBlank @Size(max = 255) String email,
   @Size(max = 255) String phoneNumber,
-  @NotBlank @Size(max = 6000) String message,
-  @NotBlank @Size(max = 10) String fromLang,
-  @NotBlank @Size(max = 10) String toLang,
-  @NotEmpty List<Long> translatorIds
+  @NonNull @NotBlank @Size(max = 6000) String message,
+  @NonNull @NotBlank @Size(max = 10) String fromLang,
+  @NonNull @NotBlank @Size(max = 10) String toLang,
+  @NonNull @NotEmpty List<Long> translatorIds
 ) {
   // Workaround for bug in IntelliJ lombok plugin
   // https://github.com/mplushnikov/lombok-intellij-plugin/issues/764

--- a/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
+++ b/src/main/java/fi/oph/akt/api/dto/translator/ContactRequestDTO.java
@@ -1,18 +1,19 @@
 package fi.oph.akt.api.dto.translator;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
 
 public record ContactRequestDTO(
-  @NotEmpty @Size(max = 255) String firstName,
-  @NotEmpty @Size(max = 255) String lastName,
-  @NotEmpty @Size(max = 255) String email,
+  @NotBlank @Size(max = 255) String firstName,
+  @NotBlank @Size(max = 255) String lastName,
+  @NotBlank @Size(max = 255) String email,
   @Size(max = 255) String phoneNumber,
-  @NotEmpty @Size(max = 6000) String message,
-  @NotEmpty @Size(max = 10) String fromLang,
-  @NotEmpty @Size(max = 10) String toLang,
+  @NotBlank @Size(max = 6000) String message,
+  @NotBlank @Size(max = 10) String fromLang,
+  @NotBlank @Size(max = 10) String toLang,
   @NotEmpty List<Long> translatorIds
 ) {
   // Workaround for bug in IntelliJ lombok plugin

--- a/src/main/reactjs/public/i18n/fi-FI/translation.json
+++ b/src/main/reactjs/public/i18n/fi-FI/translation.json
@@ -23,12 +23,12 @@
         },
         "languagePair": {
           "fromPlaceholder": "Mistä",
-          "title": "Haku kielittäin",
+          "title": "Haku kieliparilla",
           "toPlaceholder": "Mihin"
         },
         "name": {
           "placeholder": "Nimi",
-          "title": "Haku nimellä"
+          "title": "Haku kääntäjän nimellä"
         },
         "permissionToPublish": {
           "placeholder": "Kaikki",

--- a/src/main/reactjs/src/components/clerkTranslator/add/AddAuthorisation.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/add/AddAuthorisation.tsx
@@ -123,15 +123,6 @@ export const AddAuthorisation = ({
     });
   };
 
-  const handleDiaryNumberOnBlur = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    setAuthorisation({
-      ...authorisation,
-      diaryNumber: event?.target.value.trim(),
-    });
-  };
-
   const getLanguageSelectValue = (language?: string) =>
     language ? languageToComboBoxOption(translateLanguage, language) : null;
 
@@ -147,18 +138,18 @@ export const AddAuthorisation = ({
   const isAddButtonDisabled = () => {
     const { languagePair, diaryNumber, autDate, ...otherProps } = authorisation;
 
-    const isOtherPropsNotDefined = Object.values(otherProps).some(
-      (p) => Utils.isNil(p) || Utils.isEmptyString(p)
+    const isOtherPropsNotDefined = Object.values(otherProps).some((p) =>
+      Utils.isEmptyString(p)
     );
     const isLangPropsNotDefined =
       Utils.isEmptyString(languagePair.from) ||
       Utils.isEmptyString(languagePair.to);
 
-    const isDiaryNumberBlank = !diaryNumber || Utils.isBlankString(diaryNumber);
+    const isDiaryNumberBlank = Utils.isBlankString(diaryNumber);
 
     const isAutDateNotDefinedOrInvalid =
       otherProps.basis === AuthorisationBasisEnum.AUT &&
-      (autDate === undefined || !dayjs(autDate).isValid());
+      (!autDate || !dayjs(autDate).isValid());
 
     return (
       isOtherPropsNotDefined ||
@@ -264,7 +255,6 @@ export const AddAuthorisation = ({
               label={t('fieldPlaceholders.diaryNumber')}
               value={authorisation.diaryNumber}
               onChange={handleDiaryNumberChange}
-              onBlur={handleDiaryNumberOnBlur}
             />
           </div>
           <div className="rows gapped-xs">
@@ -289,7 +279,7 @@ export const AddAuthorisation = ({
         >
           {translateCommon('cancel')}
         </CustomButton>
-        {isLoading !== undefined ? (
+        {isLoading ? (
           <LoadingProgressIndicator isLoading={isLoading}>
             <CustomButton
               data-testid="add-authorisation-modal__save"

--- a/src/main/reactjs/src/components/clerkTranslator/add/AddAuthorisation.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/add/AddAuthorisation.tsx
@@ -123,6 +123,15 @@ export const AddAuthorisation = ({
     });
   };
 
+  const handleDiaryNumberOnBlur = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setAuthorisation({
+      ...authorisation,
+      diaryNumber: event?.target.value.trim(),
+    });
+  };
+
   const getLanguageSelectValue = (language?: string) =>
     language ? languageToComboBoxOption(translateLanguage, language) : null;
 
@@ -136,7 +145,7 @@ export const AddAuthorisation = ({
   };
 
   const isAddButtonDisabled = () => {
-    const { languagePair, autDate, ...otherProps } = authorisation;
+    const { languagePair, diaryNumber, autDate, ...otherProps } = authorisation;
 
     const isOtherPropsNotDefined = Object.values(otherProps).some(
       (p) => Utils.isNil(p) || Utils.isEmptyString(p)
@@ -145,6 +154,8 @@ export const AddAuthorisation = ({
       Utils.isEmptyString(languagePair.from) ||
       Utils.isEmptyString(languagePair.to);
 
+    const isDiaryNumberBlank = !diaryNumber || Utils.isBlankString(diaryNumber);
+
     const isAutDateNotDefinedOrInvalid =
       otherProps.basis === AuthorisationBasisEnum.AUT &&
       (autDate === undefined || !dayjs(autDate).isValid());
@@ -152,6 +163,7 @@ export const AddAuthorisation = ({
     return (
       isOtherPropsNotDefined ||
       isLangPropsNotDefined ||
+      isDiaryNumberBlank ||
       isAutDateNotDefinedOrInvalid
     );
   };
@@ -252,6 +264,7 @@ export const AddAuthorisation = ({
               label={t('fieldPlaceholders.diaryNumber')}
               value={authorisation.diaryNumber}
               onChange={handleDiaryNumberChange}
+              onBlur={handleDiaryNumberOnBlur}
             />
           </div>
           <div className="rows gapped-xs">

--- a/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/filters/ClerkTranslatorAutocompleteFilters.tsx
@@ -1,5 +1,3 @@
-import SearchIcon from '@mui/icons-material/Search';
-import { InputAdornment } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import { ComboBox, valueAsOption } from 'components/elements/ComboBox';
@@ -87,13 +85,6 @@ export const ClerkTranslatorAutocompleteFilters = () => {
           data-testid="clerk-translator-filters__name"
           label={t('name.placeholder')}
           type="search"
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
           value={name}
           onChange={(event) => setName(event.target.value)}
         />

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -9,20 +9,20 @@ import {
   useCommonTranslation,
 } from 'configs/i18n';
 import { TextFieldTypes } from 'enums/app';
-import { ClerkTranslatorTextFieldType } from 'enums/clerkTranslator';
+import { ClerkTranslatorTextFieldEnum } from 'enums/clerkTranslator';
 import { ClerkTranslatorBasicInformation } from 'interfaces/clerkTranslator';
 import { ClerkTranslatorTextFieldProps } from 'interfaces/clerkTranslatorTextField';
 import { Utils } from 'utils';
 
-const getTextFieldType = (fieldType: ClerkTranslatorTextFieldType) => {
-  switch (fieldType) {
-    case ClerkTranslatorTextFieldType.PhoneNumber:
+const getTextFieldType = (field: ClerkTranslatorTextFieldEnum) => {
+  switch (field) {
+    case ClerkTranslatorTextFieldEnum.PhoneNumber:
       return TextFieldTypes.PhoneNumber;
-    case ClerkTranslatorTextFieldType.Email:
+    case ClerkTranslatorTextFieldEnum.Email:
       return TextFieldTypes.Email;
-    case ClerkTranslatorTextFieldType.ExtraInformation:
+    case ClerkTranslatorTextFieldEnum.ExtraInformation:
       return TextFieldTypes.Textarea;
-    case ClerkTranslatorTextFieldType.IdentityNumber:
+    case ClerkTranslatorTextFieldEnum.IdentityNumber:
       return TextFieldTypes.PersonalIdentityCode;
     default:
       return TextFieldTypes.Text;
@@ -31,27 +31,23 @@ const getTextFieldType = (fieldType: ClerkTranslatorTextFieldType) => {
 
 const getFieldError = (
   translator: ClerkTranslatorBasicInformation | undefined,
-  fieldType: ClerkTranslatorTextFieldType
+  field: ClerkTranslatorTextFieldEnum
 ) => {
   const t = translateOutsideComponent();
-  const textFieldType = getTextFieldType(fieldType);
-  const fieldValue = (translator && translator[fieldType]) || '';
+  const type = getTextFieldType(field);
+  const value = (translator && translator[field]) || '';
   const required =
-    fieldType == ClerkTranslatorTextFieldType.FirstName ||
-    fieldType == ClerkTranslatorTextFieldType.LastName;
+    field == ClerkTranslatorTextFieldEnum.FirstName ||
+    field == ClerkTranslatorTextFieldEnum.LastName;
 
-  const error = Utils.inspectCustomTextFieldErrors(
-    textFieldType,
-    fieldValue,
-    required
-  );
+  const error = Utils.inspectCustomTextFieldErrors(type, value, required);
 
   return error ? t(`akt.${error}`) : '';
 };
 
 const ClerkTranslatorDetailsTextField = ({
   translator,
-  fieldType,
+  field,
   onChange,
   displayError,
   ...rest
@@ -60,15 +56,15 @@ const ClerkTranslatorDetailsTextField = ({
   const { t } = useAppTranslation({
     keyPrefix: 'akt.component.clerkTranslatorOverview.translatorDetails.fields',
   });
-  const fieldError = getFieldError(translator, fieldType);
+  const fieldError = getFieldError(translator, field);
 
   return (
     <CustomTextField
-      value={translator ? translator[fieldType] : undefined}
-      label={t(fieldType)}
-      data-testid={`clerk-translator-overview__translator-details__field-${fieldType}`}
+      value={translator ? translator[field] : undefined}
+      label={t(field)}
+      data-testid={`clerk-translator-overview__translator-details__field-${field}`}
       onChange={onChange}
-      type={getTextFieldType(fieldType)}
+      type={getTextFieldType(field)}
       error={displayError && fieldError?.length > 0}
       helperText={fieldError}
       {...rest}
@@ -97,30 +93,28 @@ export const ClerkTranslatorDetailsFields = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const initialErrors = Object.values(ClerkTranslatorTextFieldType).reduce(
+  const initialErrors = Object.values(ClerkTranslatorTextFieldEnum).reduce(
     (acc, val) => {
       return { ...acc, [val]: displayFieldErrorBeforeChange };
     },
     {}
-  ) as Record<ClerkTranslatorTextFieldType, boolean>;
+  ) as Record<ClerkTranslatorTextFieldEnum, boolean>;
 
   const [displayFieldError, setDisplayFieldError] = useState(initialErrors);
-  const onFieldBlur = (fieldType: ClerkTranslatorTextFieldType) => () => {
-    if (translator && fieldType) {
-      translator[fieldType] = (translator[fieldType] as string).trim();
+  const onFieldBlur = (field: ClerkTranslatorTextFieldEnum) => () => {
+    if (translator && field) {
+      translator[field] = (translator[field] as string).trim();
     }
-    setDisplayFieldError({ ...displayFieldError, [fieldType]: true });
+    setDisplayFieldError({ ...displayFieldError, [field]: true });
   };
 
-  const getCommonTextFieldProps = (
-    fieldType: ClerkTranslatorTextFieldType
-  ) => ({
-    fieldType,
+  const getCommonTextFieldProps = (field: ClerkTranslatorTextFieldEnum) => ({
+    field,
     translator,
     disabled: editDisabled,
-    onChange: onFieldChange(fieldType),
-    onBlur: onFieldBlur(fieldType),
-    displayError: displayFieldError[fieldType],
+    onChange: onFieldChange(field),
+    onBlur: onFieldBlur(field),
+    displayError: displayFieldError[field],
   });
 
   return (
@@ -133,45 +127,45 @@ export const ClerkTranslatorDetailsFields = ({
       </div>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.LastName)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.LastName)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.FirstName)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.FirstName)}
         />
         <ClerkTranslatorDetailsTextField
           {...getCommonTextFieldProps(
-            ClerkTranslatorTextFieldType.IdentityNumber
+            ClerkTranslatorTextFieldEnum.IdentityNumber
           )}
         />
       </div>
       <H3>{t('header.address')}</H3>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Street)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.Street)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.PostalCode)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.PostalCode)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Town)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.Town)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Country)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.Country)}
         />
       </div>
       <H3>{t('header.contactInformation')}</H3>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Email)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.Email)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.PhoneNumber)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldEnum.PhoneNumber)}
         />
       </div>
       <H3>{t('header.extraInformation')}</H3>
       <ClerkTranslatorDetailsTextField
         {...getCommonTextFieldProps(
-          ClerkTranslatorTextFieldType.ExtraInformation
+          ClerkTranslatorTextFieldEnum.ExtraInformation
         )}
         multiline
         fullWidth

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -101,19 +101,17 @@ export const ClerkTranslatorDetailsFields = ({
   ) as Record<ClerkTranslatorTextFieldEnum, boolean>;
 
   const [displayFieldError, setDisplayFieldError] = useState(initialErrors);
-  const onFieldBlur = (field: ClerkTranslatorTextFieldEnum) => () => {
-    if (translator && field) {
-      translator[field] = (translator[field] as string).trim();
-    }
-    setDisplayFieldError({ ...displayFieldError, [field]: true });
-  };
+  const displayFieldErrorOnBlur =
+    (field: ClerkTranslatorTextFieldEnum) => () => {
+      setDisplayFieldError({ ...displayFieldError, [field]: true });
+    };
 
   const getCommonTextFieldProps = (field: ClerkTranslatorTextFieldEnum) => ({
     field,
     translator,
     disabled: editDisabled,
     onChange: onFieldChange(field),
-    onBlur: onFieldBlur(field),
+    onBlur: displayFieldErrorOnBlur(field),
     displayError: displayFieldError[field],
   });
 

--- a/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
+++ b/src/main/reactjs/src/components/clerkTranslator/overview/ClerkTranslatorDetailsFields.tsx
@@ -9,20 +9,20 @@ import {
   useCommonTranslation,
 } from 'configs/i18n';
 import { TextFieldTypes } from 'enums/app';
-import { ClerkTranslatorTextField } from 'enums/clerkTranslator';
+import { ClerkTranslatorTextFieldType } from 'enums/clerkTranslator';
 import { ClerkTranslatorBasicInformation } from 'interfaces/clerkTranslator';
 import { ClerkTranslatorTextFieldProps } from 'interfaces/clerkTranslatorTextField';
 import { Utils } from 'utils';
 
-const getFieldType = (field: ClerkTranslatorTextField) => {
-  switch (field) {
-    case ClerkTranslatorTextField.PhoneNumber:
+const getTextFieldType = (fieldType: ClerkTranslatorTextFieldType) => {
+  switch (fieldType) {
+    case ClerkTranslatorTextFieldType.PhoneNumber:
       return TextFieldTypes.PhoneNumber;
-    case ClerkTranslatorTextField.Email:
+    case ClerkTranslatorTextFieldType.Email:
       return TextFieldTypes.Email;
-    case ClerkTranslatorTextField.ExtraInformation:
+    case ClerkTranslatorTextFieldType.ExtraInformation:
       return TextFieldTypes.Textarea;
-    case ClerkTranslatorTextField.IdentityNumber:
+    case ClerkTranslatorTextFieldType.IdentityNumber:
       return TextFieldTypes.PersonalIdentityCode;
     default:
       return TextFieldTypes.Text;
@@ -31,22 +31,27 @@ const getFieldType = (field: ClerkTranslatorTextField) => {
 
 const getFieldError = (
   translator: ClerkTranslatorBasicInformation | undefined,
-  field: ClerkTranslatorTextField
+  fieldType: ClerkTranslatorTextFieldType
 ) => {
   const t = translateOutsideComponent();
-  const type = getFieldType(field);
-  const fieldValue = (translator && translator[field]) || '';
+  const textFieldType = getTextFieldType(fieldType);
+  const fieldValue = (translator && translator[fieldType]) || '';
   const required =
-    field == ClerkTranslatorTextField.FirstName ||
-    field == ClerkTranslatorTextField.LastName;
-  const error = Utils.inspectCustomTextFieldErrors(type, fieldValue, required);
+    fieldType == ClerkTranslatorTextFieldType.FirstName ||
+    fieldType == ClerkTranslatorTextFieldType.LastName;
+
+  const error = Utils.inspectCustomTextFieldErrors(
+    textFieldType,
+    fieldValue,
+    required
+  );
 
   return error ? t(`akt.${error}`) : '';
 };
 
 const ClerkTranslatorDetailsTextField = ({
   translator,
-  field,
+  fieldType,
   onChange,
   displayError,
   ...rest
@@ -55,15 +60,15 @@ const ClerkTranslatorDetailsTextField = ({
   const { t } = useAppTranslation({
     keyPrefix: 'akt.component.clerkTranslatorOverview.translatorDetails.fields',
   });
-  const fieldError = getFieldError(translator, field);
+  const fieldError = getFieldError(translator, fieldType);
 
   return (
     <CustomTextField
-      value={translator ? translator[field] : undefined}
-      label={t(field)}
-      data-testid={`clerk-translator-overview__translator-details__field-${field}`}
+      value={translator ? translator[fieldType] : undefined}
+      label={t(fieldType)}
+      data-testid={`clerk-translator-overview__translator-details__field-${fieldType}`}
       onChange={onChange}
-      type={getFieldType(field)}
+      type={getTextFieldType(fieldType)}
       error={displayError && fieldError?.length > 0}
       helperText={fieldError}
       {...rest}
@@ -92,24 +97,30 @@ export const ClerkTranslatorDetailsFields = ({
   });
   const translateCommon = useCommonTranslation();
 
-  const initialErrors = Object.values(ClerkTranslatorTextField).reduce(
+  const initialErrors = Object.values(ClerkTranslatorTextFieldType).reduce(
     (acc, val) => {
       return { ...acc, [val]: displayFieldErrorBeforeChange };
     },
     {}
-  ) as Record<ClerkTranslatorTextField, boolean>;
+  ) as Record<ClerkTranslatorTextFieldType, boolean>;
+
   const [displayFieldError, setDisplayFieldError] = useState(initialErrors);
-  const displayFieldErrorOnBlur = (field: ClerkTranslatorTextField) => () => {
-    setDisplayFieldError({ ...displayFieldError, [field]: true });
+  const onFieldBlur = (fieldType: ClerkTranslatorTextFieldType) => () => {
+    if (translator && fieldType) {
+      translator[fieldType] = (translator[fieldType] as string).trim();
+    }
+    setDisplayFieldError({ ...displayFieldError, [fieldType]: true });
   };
 
-  const getCommonTextFieldProps = (field: ClerkTranslatorTextField) => ({
-    field,
+  const getCommonTextFieldProps = (
+    fieldType: ClerkTranslatorTextFieldType
+  ) => ({
+    fieldType,
     translator,
     disabled: editDisabled,
-    onChange: onFieldChange(field),
-    onBlur: displayFieldErrorOnBlur(field),
-    displayError: displayFieldError[field],
+    onChange: onFieldChange(fieldType),
+    onBlur: onFieldBlur(fieldType),
+    displayError: displayFieldError[fieldType],
   });
 
   return (
@@ -122,42 +133,46 @@ export const ClerkTranslatorDetailsFields = ({
       </div>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.LastName)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.LastName)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.FirstName)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.FirstName)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.IdentityNumber)}
+          {...getCommonTextFieldProps(
+            ClerkTranslatorTextFieldType.IdentityNumber
+          )}
         />
       </div>
       <H3>{t('header.address')}</H3>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.Street)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Street)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.PostalCode)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.PostalCode)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.Town)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Town)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.Country)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Country)}
         />
       </div>
       <H3>{t('header.contactInformation')}</H3>
       <div className="grid-columns gapped">
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.Email)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.Email)}
         />
         <ClerkTranslatorDetailsTextField
-          {...getCommonTextFieldProps(ClerkTranslatorTextField.PhoneNumber)}
+          {...getCommonTextFieldProps(ClerkTranslatorTextFieldType.PhoneNumber)}
         />
       </div>
       <H3>{t('header.extraInformation')}</H3>
       <ClerkTranslatorDetailsTextField
-        {...getCommonTextFieldProps(ClerkTranslatorTextField.ExtraInformation)}
+        {...getCommonTextFieldProps(
+          ClerkTranslatorTextFieldType.ExtraInformation
+        )}
         multiline
         fullWidth
       />

--- a/src/main/reactjs/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/src/main/reactjs/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -49,8 +49,8 @@ export const FillContactDetails = ({
       fieldErrors.lastName ||
       fieldErrors.email
     );
-    const hasBlankRequiredFields = requiredFieldValues.some(
-      (v) => !v || Utils.isBlankString(v)
+    const hasBlankRequiredFields = requiredFieldValues.some((v) =>
+      Utils.isBlankString(v)
     );
 
     disableNext(hasFieldErrors || hasBlankRequiredFields);
@@ -70,25 +70,13 @@ export const FillContactDetails = ({
       );
     };
 
-  const handleContactDetailsBlur =
-    (fieldName: keyof ContactDetails) =>
-    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      handleContactDetailsErrors(fieldName)(event);
-
-      dispatch(
-        setContactRequest({
-          [fieldName]: event.target.value.trim(),
-        })
-      );
-    };
-
   const handleContactDetailsErrors =
     (fieldName: keyof ContactDetails) =>
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const { type, value, required } = event.target;
       const error = Utils.inspectCustomTextFieldErrors(
         type as TextFieldTypes,
-        value.trim(),
+        value,
         required
       );
 
@@ -103,7 +91,7 @@ export const FillContactDetails = ({
   const getCustomTextFieldAttributes = (fieldName: keyof ContactDetails) => ({
     id: `contact-details__${fieldName}-field`,
     label: t(`component.contactRequestForm.formLabels.${fieldName}`),
-    onBlur: handleContactDetailsBlur(fieldName),
+    onBlur: handleContactDetailsErrors(fieldName),
     onChange: handleContactDetailsChange(fieldName),
     error: showCustomTextFieldError(fieldName),
     helperText: fieldErrors[fieldName],

--- a/src/main/reactjs/src/components/contactRequest/steps/FillContactDetails.tsx
+++ b/src/main/reactjs/src/components/contactRequest/steps/FillContactDetails.tsx
@@ -49,9 +49,11 @@ export const FillContactDetails = ({
       fieldErrors.lastName ||
       fieldErrors.email
     );
-    const hasEmptyRequiredFields = requiredFieldValues.some((v) => !!!v);
+    const hasBlankRequiredFields = requiredFieldValues.some(
+      (v) => !v || Utils.isBlankString(v)
+    );
 
-    disableNext(hasFieldErrors || hasEmptyRequiredFields);
+    disableNext(hasFieldErrors || hasBlankRequiredFields);
   }, [fieldErrors, disableNext, request]);
 
   const handleContactDetailsChange =
@@ -68,13 +70,25 @@ export const FillContactDetails = ({
       );
     };
 
+  const handleContactDetailsBlur =
+    (fieldName: keyof ContactDetails) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      handleContactDetailsErrors(fieldName)(event);
+
+      dispatch(
+        setContactRequest({
+          [fieldName]: event.target.value.trim(),
+        })
+      );
+    };
+
   const handleContactDetailsErrors =
     (fieldName: keyof ContactDetails) =>
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const { type, value, required } = event.target;
       const error = Utils.inspectCustomTextFieldErrors(
         type as TextFieldTypes,
-        value,
+        value.trim(),
         required
       );
 
@@ -89,7 +103,7 @@ export const FillContactDetails = ({
   const getCustomTextFieldAttributes = (fieldName: keyof ContactDetails) => ({
     id: `contact-details__${fieldName}-field`,
     label: t(`component.contactRequestForm.formLabels.${fieldName}`),
-    onBlur: handleContactDetailsErrors(fieldName),
+    onBlur: handleContactDetailsBlur(fieldName),
     onChange: handleContactDetailsChange(fieldName),
     error: showCustomTextFieldError(fieldName),
     helperText: fieldErrors[fieldName],

--- a/src/main/reactjs/src/components/contactRequest/steps/WriteMessage.tsx
+++ b/src/main/reactjs/src/components/contactRequest/steps/WriteMessage.tsx
@@ -38,8 +38,7 @@ export const WriteMessage = ({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    const hasBlankMessage =
-      !request?.message || Utils.isBlankString(request.message);
+    const hasBlankMessage = Utils.isBlankString(request?.message);
     const hasFieldError = fieldError.length > 0;
 
     disableNext(hasBlankMessage || hasFieldError);
@@ -54,20 +53,13 @@ export const WriteMessage = ({
     dispatch(setContactRequest({ message: event.target.value }));
   };
 
-  const handleMessageFieldBlur = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    handleMessageFieldErrors(event);
-    dispatch(setContactRequest({ message: event.target.value.trim() }));
-  };
-
   const handleMessageFieldErrors = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { type, value, required } = event.target;
     const error = Utils.inspectCustomTextFieldErrors(
       type as TextFieldTypes,
-      value.trim(),
+      value,
       required
     );
 
@@ -107,7 +99,7 @@ export const WriteMessage = ({
             )}
             value={request?.message}
             type={TextFieldTypes.Textarea}
-            onBlur={handleMessageFieldBlur}
+            onBlur={handleMessageFieldErrors}
             onChange={handleMessageFieldChange}
             showHelperText
             helperText={getHelperMessage()}

--- a/src/main/reactjs/src/components/contactRequest/steps/WriteMessage.tsx
+++ b/src/main/reactjs/src/components/contactRequest/steps/WriteMessage.tsx
@@ -38,10 +38,11 @@ export const WriteMessage = ({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    const hasEmptyMessage = !!!request?.message;
+    const hasBlankMessage =
+      !request?.message || Utils.isBlankString(request.message);
     const hasFieldError = fieldError.length > 0;
 
-    disableNext(hasEmptyMessage || hasFieldError);
+    disableNext(hasBlankMessage || hasFieldError);
   }, [disableNext, fieldError, request]);
 
   const handleMessageFieldChange = (
@@ -53,13 +54,20 @@ export const WriteMessage = ({
     dispatch(setContactRequest({ message: event.target.value }));
   };
 
+  const handleMessageFieldBlur = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    handleMessageFieldErrors(event);
+    dispatch(setContactRequest({ message: event.target.value.trim() }));
+  };
+
   const handleMessageFieldErrors = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { type, value, required } = event.target;
     const error = Utils.inspectCustomTextFieldErrors(
       type as TextFieldTypes,
-      value,
+      value.trim(),
       required
     );
 
@@ -99,7 +107,7 @@ export const WriteMessage = ({
             )}
             value={request?.message}
             type={TextFieldTypes.Textarea}
-            onBlur={handleMessageFieldErrors}
+            onBlur={handleMessageFieldBlur}
             onChange={handleMessageFieldChange}
             showHelperText
             helperText={getHelperMessage()}

--- a/src/main/reactjs/src/enums/clerkTranslator.ts
+++ b/src/main/reactjs/src/enums/clerkTranslator.ts
@@ -14,7 +14,7 @@ export enum AuthorisationBasisEnum {
   VIR = 'VIR',
 }
 
-export enum ClerkTranslatorTextFieldType {
+export enum ClerkTranslatorTextFieldEnum {
   FirstName = 'firstName',
   LastName = 'lastName',
   IdentityNumber = 'identityNumber',

--- a/src/main/reactjs/src/enums/clerkTranslator.ts
+++ b/src/main/reactjs/src/enums/clerkTranslator.ts
@@ -14,7 +14,7 @@ export enum AuthorisationBasisEnum {
   VIR = 'VIR',
 }
 
-export enum ClerkTranslatorTextField {
+export enum ClerkTranslatorTextFieldType {
   FirstName = 'firstName',
   LastName = 'lastName',
   IdentityNumber = 'identityNumber',

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -5,19 +5,11 @@ import {
   AuthorisationBasis,
   AuthorisationResponse,
 } from 'interfaces/authorisation';
+import { ClerkTranslatorTextField } from 'interfaces/clerkTranslatorTextField';
 import { WithId, WithVersion } from 'interfaces/with';
 
-export interface ClerkTranslatorBasicInformation {
-  firstName: string;
-  lastName: string;
-  identityNumber?: string;
-  email?: string;
-  phoneNumber?: string;
-  street?: string;
-  postalCode?: string;
-  town?: string;
-  country?: string;
-  extraInformation?: string;
+export interface ClerkTranslatorBasicInformation
+  extends ClerkTranslatorTextField {
   isAssuranceGiven: boolean;
 }
 

--- a/src/main/reactjs/src/interfaces/clerkTranslator.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslator.ts
@@ -5,11 +5,23 @@ import {
   AuthorisationBasis,
   AuthorisationResponse,
 } from 'interfaces/authorisation';
-import { ClerkTranslatorTextField } from 'interfaces/clerkTranslatorTextField';
 import { WithId, WithVersion } from 'interfaces/with';
 
+export interface ClerkTranslatorTextFields {
+  firstName: string;
+  lastName: string;
+  identityNumber?: string;
+  email?: string;
+  phoneNumber?: string;
+  street?: string;
+  postalCode?: string;
+  town?: string;
+  country?: string;
+  extraInformation?: string;
+}
+
 export interface ClerkTranslatorBasicInformation
-  extends ClerkTranslatorTextField {
+  extends ClerkTranslatorTextFields {
   isAssuranceGiven: boolean;
 }
 

--- a/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
@@ -1,25 +1,12 @@
 import { ChangeEvent } from 'react';
 
-import { ClerkTranslatorTextFieldType } from 'enums/clerkTranslator';
+import { ClerkTranslatorTextFieldEnum } from 'enums/clerkTranslator';
 import { ClerkTranslatorBasicInformation } from 'interfaces/clerkTranslator';
 import { CustomTextFieldProps } from 'interfaces/components/customTextField';
 
 export type ClerkTranslatorTextFieldProps = {
   translator?: ClerkTranslatorBasicInformation;
-  fieldType: ClerkTranslatorTextFieldType;
+  field: ClerkTranslatorTextFieldEnum;
   displayError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 } & CustomTextFieldProps;
-
-export interface ClerkTranslatorTextField {
-  firstName: string;
-  lastName: string;
-  identityNumber?: string;
-  email?: string;
-  phoneNumber?: string;
-  street?: string;
-  postalCode?: string;
-  town?: string;
-  country?: string;
-  extraInformation?: string;
-}

--- a/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
+++ b/src/main/reactjs/src/interfaces/clerkTranslatorTextField.ts
@@ -1,12 +1,25 @@
 import { ChangeEvent } from 'react';
 
-import { ClerkTranslatorTextField } from 'enums/clerkTranslator';
+import { ClerkTranslatorTextFieldType } from 'enums/clerkTranslator';
 import { ClerkTranslatorBasicInformation } from 'interfaces/clerkTranslator';
 import { CustomTextFieldProps } from 'interfaces/components/customTextField';
 
 export type ClerkTranslatorTextFieldProps = {
   translator?: ClerkTranslatorBasicInformation;
-  field: ClerkTranslatorTextField;
+  fieldType: ClerkTranslatorTextFieldType;
   displayError: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 } & CustomTextFieldProps;
+
+export interface ClerkTranslatorTextField {
+  firstName: string;
+  lastName: string;
+  identityNumber?: string;
+  email?: string;
+  phoneNumber?: string;
+  street?: string;
+  postalCode?: string;
+  town?: string;
+  country?: string;
+  extraInformation?: string;
+}

--- a/src/main/reactjs/src/pages/clerk/ClerkSendEmailPage.tsx
+++ b/src/main/reactjs/src/pages/clerk/ClerkSendEmailPage.tsx
@@ -147,7 +147,7 @@ export const ClerkSendEmailPage = () => {
       const { value, required } = event.target;
       const error = Utils.inspectCustomTextFieldErrors(
         field == 'subject' ? TextFieldTypes.Text : TextFieldTypes.Textarea,
-        value.trim(),
+        value,
         required
       );
       const errorMessage = error ? t(error) : '';
@@ -166,20 +166,6 @@ export const ClerkSendEmailPage = () => {
   ) => {
     setEmailBody(event.target.value);
     handleFieldError('message')(event);
-  };
-
-  const handleSubjectBlur = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    handleFieldError('subject')(event);
-    setEmailSubject(event.target.value.trim());
-  };
-
-  const handleMessageBlur = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    handleFieldError('message')(event);
-    setEmailBody(event.target.value.trim());
   };
 
   return (
@@ -202,7 +188,7 @@ export const ClerkSendEmailPage = () => {
               label={t('pages.clerkSendEmailPage.labels.subject')}
               value={email.subject}
               onChange={handleSubjectChange}
-              onBlur={handleSubjectBlur}
+              onBlur={handleFieldError('subject')}
               error={fieldErrors.subject.length > 0}
               helperText={fieldErrors.subject}
               required
@@ -215,7 +201,7 @@ export const ClerkSendEmailPage = () => {
               label={t('pages.clerkSendEmailPage.labels.message')}
               value={email.body}
               onChange={handleMessageChange}
-              onBlur={handleMessageBlur}
+              onBlur={handleFieldError('message')}
               error={fieldErrors.message.length > 0}
               helperText={fieldErrors.message}
               multiline

--- a/src/main/reactjs/src/pages/clerk/ClerkSendEmailPage.tsx
+++ b/src/main/reactjs/src/pages/clerk/ClerkSendEmailPage.tsx
@@ -125,8 +125,8 @@ export const ClerkSendEmailPage = () => {
   const [fieldErrors, setFieldErrors] =
     useState<typeof initialFieldErrors>(initialFieldErrors);
   const submitDisabled =
-    Utils.isEmptyString(email.subject) ||
-    Utils.isEmptyString(email.body) ||
+    Utils.isBlankString(email.subject) ||
+    Utils.isBlankString(email.body) ||
     translators.length == 0;
 
   // Navigation
@@ -147,7 +147,7 @@ export const ClerkSendEmailPage = () => {
       const { value, required } = event.target;
       const error = Utils.inspectCustomTextFieldErrors(
         field == 'subject' ? TextFieldTypes.Text : TextFieldTypes.Textarea,
-        value,
+        value.trim(),
         required
       );
       const errorMessage = error ? t(error) : '';
@@ -166,6 +166,20 @@ export const ClerkSendEmailPage = () => {
   ) => {
     setEmailBody(event.target.value);
     handleFieldError('message')(event);
+  };
+
+  const handleSubjectBlur = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    handleFieldError('subject')(event);
+    setEmailSubject(event.target.value.trim());
+  };
+
+  const handleMessageBlur = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    handleFieldError('message')(event);
+    setEmailBody(event.target.value.trim());
   };
 
   return (
@@ -188,7 +202,7 @@ export const ClerkSendEmailPage = () => {
               label={t('pages.clerkSendEmailPage.labels.subject')}
               value={email.subject}
               onChange={handleSubjectChange}
-              onBlur={handleFieldError('subject')}
+              onBlur={handleSubjectBlur}
               error={fieldErrors.subject.length > 0}
               helperText={fieldErrors.subject}
               required
@@ -201,7 +215,7 @@ export const ClerkSendEmailPage = () => {
               label={t('pages.clerkSendEmailPage.labels.message')}
               value={email.body}
               onChange={handleMessageChange}
-              onBlur={handleFieldError('message')}
+              onBlur={handleMessageBlur}
               error={fieldErrors.message.length > 0}
               helperText={fieldErrors.message}
               multiline

--- a/src/main/reactjs/src/redux/reducers/clerkTranslator.ts
+++ b/src/main/reactjs/src/redux/reducers/clerkTranslator.ts
@@ -83,6 +83,7 @@ export const clerkTranslatorReducer: Reducer<ClerkUIState, ClerkStateAction> = (
         ...state,
         filters: { ...state.filters, ...filters },
       };
+    // TODO: should clear content in name search component
     case CLERK_TRANSLATOR_RESET_FILTERS:
       return {
         ...state,

--- a/src/main/reactjs/src/redux/sagas/authorisation.ts
+++ b/src/main/reactjs/src/redux/sagas/authorisation.ts
@@ -50,7 +50,7 @@ const createAuthorisationBody = ({
     termBeginDate: formatDate(termBeginDate),
     termEndDate: formatDate(termEndDate),
     permissionToPublish,
-    diaryNumber,
+    diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
     ...(basis === AuthorisationBasisEnum.AUT && {
       autDate: formatDate(autDate),
     }),

--- a/src/main/reactjs/src/redux/sagas/clerkTranslatorEmail.ts
+++ b/src/main/reactjs/src/redux/sagas/clerkTranslatorEmail.ts
@@ -45,8 +45,8 @@ export function* sendEmail() {
       axiosInstance.post,
       APIEndpoints.InformalClerkTranslatorEmail,
       JSON.stringify({
-        subject: email.subject,
-        body: email.body,
+        subject: email.subject.trim(),
+        body: email.body.trim(),
         translatorIds: recipients,
       })
     );

--- a/src/main/reactjs/src/redux/sagas/clerkTranslatorOverview.ts
+++ b/src/main/reactjs/src/redux/sagas/clerkTranslatorOverview.ts
@@ -78,7 +78,9 @@ function* updateClerkTranslatorDetails(action: ClerkTranslatorOverviewAction) {
     const apiResponse: AxiosResponse<ClerkTranslatorResponse> = yield call(
       axiosInstance.put,
       APIEndpoints.ClerkTranslator,
-      JSON.stringify(action.translator)
+      APIUtils.convertClerkTranslatorToAPIRequest(
+        action.translator as ClerkTranslator
+      )
     );
     const translator = APIUtils.convertClerkTranslatorResponse(
       apiResponse.data
@@ -113,7 +115,6 @@ function* updateAuthorisationPublishPermission(action: AuthorisationAction) {
       APIEndpoints.AuthorisationPublishPermission,
       requestBody
     );
-
     const translator = APIUtils.convertClerkTranslatorResponse(
       apiResponse.data
     );

--- a/src/main/reactjs/src/redux/sagas/contactRequest.ts
+++ b/src/main/reactjs/src/redux/sagas/contactRequest.ts
@@ -35,12 +35,12 @@ export function* sendContactRequest(action: Action) {
         axiosInstance.post,
         APIEndpoints.ContactRequest,
         JSON.stringify({
-          firstName,
-          lastName,
-          email,
-          phoneNumber,
+          firstName: firstName.trim(),
+          lastName: lastName.trim(),
+          email: email.trim(),
+          phoneNumber: phoneNumber ? phoneNumber.trim() : undefined,
           translatorIds,
-          message,
+          message: message.trim(),
           fromLang: languagePair.from,
           toLang: languagePair.to,
         })

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -3,8 +3,8 @@ import { ClerkNewTranslator } from 'interfaces/clerkNewTranslator';
 import {
   ClerkTranslator,
   ClerkTranslatorResponse,
+  ClerkTranslatorTextFields,
 } from 'interfaces/clerkTranslator';
-import { ClerkTranslatorTextField } from 'interfaces/clerkTranslatorTextField';
 import { MeetingDateResponse } from 'interfaces/meetingDate';
 import { DateUtils } from 'utils/date';
 
@@ -78,10 +78,10 @@ export class APIUtils {
   }
 
   private static getNonBlankClerkTranslatorTextFields(
-    textFields: ClerkTranslatorTextField
+    textFields: ClerkTranslatorTextFields
   ) {
     Object.keys(textFields).forEach((key) => {
-      const field = key as keyof ClerkTranslatorTextField;
+      const field = key as keyof ClerkTranslatorTextFields;
 
       if (!textFields[field]) {
         delete textFields[field];

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -1,3 +1,4 @@
+import { AuthorisationBasisEnum } from 'enums/clerkTranslator';
 import { Authorisation, AuthorisationResponse } from 'interfaces/authorisation';
 import { ClerkNewTranslator } from 'interfaces/clerkNewTranslator';
 import {
@@ -111,9 +112,11 @@ export class APIUtils {
       basis,
       termBeginDate: DateUtils.convertToAPIRequestDateString(termBeginDate),
       termEndDate: DateUtils.convertToAPIRequestDateString(termEndDate),
-      autDate: DateUtils.convertToAPIRequestDateString(autDate),
       permissionToPublish,
       diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
+      ...(basis === AuthorisationBasisEnum.AUT && {
+        autDate: DateUtils.convertToAPIRequestDateString(autDate),
+      }),
     };
   }
 }

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -1,8 +1,10 @@
 import { Authorisation, AuthorisationResponse } from 'interfaces/authorisation';
+import { ClerkNewTranslator } from 'interfaces/clerkNewTranslator';
 import {
   ClerkTranslator,
   ClerkTranslatorResponse,
 } from 'interfaces/clerkTranslator';
+import { ClerkTranslatorTextField } from 'interfaces/clerkTranslatorTextField';
 import { MeetingDateResponse } from 'interfaces/meetingDate';
 import { DateUtils } from 'utils/date';
 
@@ -42,6 +44,51 @@ export class APIUtils {
         APIUtils.convertAuthorisationResponse
       ),
     };
+  }
+
+  static convertClerkNewTranslatorToAPIRequest(translator: ClerkNewTranslator) {
+    const { isAssuranceGiven, authorisations, ...rest } = translator;
+    const textFields = APIUtils.getNonBlankClerkTranslatorTextFields(rest);
+
+    return {
+      ...textFields,
+      isAssuranceGiven,
+      authorisations: authorisations.map(
+        APIUtils.convertAuthorisationToAPIRequest
+      ),
+    };
+  }
+
+  static convertClerkTranslatorToAPIRequest(translator: ClerkTranslator) {
+    const {
+      id,
+      version,
+      isAssuranceGiven,
+      authorisations: _ignored,
+      ...rest
+    } = translator;
+    const textFields = APIUtils.getNonBlankClerkTranslatorTextFields(rest);
+
+    return {
+      ...textFields,
+      id,
+      version,
+      isAssuranceGiven,
+    };
+  }
+
+  private static getNonBlankClerkTranslatorTextFields(
+    textFields: ClerkTranslatorTextField
+  ) {
+    Object.keys(textFields).forEach((key) => {
+      const field = key as keyof ClerkTranslatorTextField;
+
+      if (!textFields[field]) {
+        delete textFields[field];
+      }
+    });
+
+    return textFields;
   }
 
   static convertAuthorisationToAPIRequest(authorisation: Authorisation) {

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -113,7 +113,7 @@ export class APIUtils {
       termEndDate: DateUtils.convertToAPIRequestDateString(termEndDate),
       autDate: DateUtils.convertToAPIRequestDateString(autDate),
       permissionToPublish,
-      diaryNumber,
+      diaryNumber: diaryNumber ? diaryNumber.trim() : undefined,
     };
   }
 }

--- a/src/main/reactjs/src/utils/api.ts
+++ b/src/main/reactjs/src/utils/api.ts
@@ -83,6 +83,9 @@ export class APIUtils {
     Object.keys(textFields).forEach((key) => {
       const field = key as keyof ClerkTranslatorTextFields;
 
+      if (textFields[field]) {
+        textFields[field] = (textFields[field] as string).trim();
+      }
       if (!textFields[field]) {
         delete textFields[field];
       }

--- a/src/main/reactjs/src/utils/index.ts
+++ b/src/main/reactjs/src/utils/index.ts
@@ -18,6 +18,14 @@ export class Utils {
     window.scrollTo({ top: 0, left: 0 });
   }
 
+  static isBlankString(str: string) {
+    if (typeof str === 'string') {
+      return str.trim().length === 0;
+    }
+
+    return false;
+  }
+
   static isEmptyString(str: string) {
     if (typeof str === 'string') {
       return str.length === 0;

--- a/src/main/reactjs/src/utils/index.ts
+++ b/src/main/reactjs/src/utils/index.ts
@@ -18,24 +18,22 @@ export class Utils {
     window.scrollTo({ top: 0, left: 0 });
   }
 
-  static isBlankString(str: string) {
-    if (typeof str === 'string') {
-      return str.trim().length === 0;
-    }
-
-    return false;
+  /**
+   * Value is an empty string if it's undefined, or its length is zero.
+   * @param value
+   * @returns
+   */
+  static isEmptyString(value?: string) {
+    return !value || value.length === 0;
   }
 
-  static isEmptyString(str: string) {
-    if (typeof str === 'string') {
-      return str.length === 0;
-    }
-
-    return false;
-  }
-
-  static isNil(value: unknown) {
-    return value == null;
+  /**
+   * Value is a blank string if it's undefined, or its trimmed length is zero.
+   * @param value
+   * @returns
+   */
+  static isBlankString(value?: string) {
+    return !value || value.trim().length === 0;
   }
 
   static createMapFromArray(
@@ -121,32 +119,34 @@ export class Utils {
     value: string,
     required = true
   ) {
-    if (required && value.length <= 0) {
+    const trimmedValue = value.trim();
+
+    if (required && trimmedValue.length <= 0) {
       return CustomTextFieldErrors.Required;
     }
 
-    if (!required && value.length == 0) {
+    if (!required && trimmedValue.length == 0) {
       return '';
     }
 
     switch (type) {
       case TextFieldTypes.Textarea:
-        if (value.length > Utils.getMaxTextAreaLength()) {
+        if (trimmedValue.length > Utils.getMaxTextAreaLength()) {
           return CustomTextFieldErrors.MaxLength;
         }
         break;
       case TextFieldTypes.Email:
-        if (!Utils.EMAIL_REG_EXR.test(value)) {
+        if (!Utils.EMAIL_REG_EXR.test(trimmedValue)) {
           return CustomTextFieldErrors.EmailFormat;
         }
         break;
       case TextFieldTypes.PhoneNumber:
-        if (!Utils.TEL_REG_EXR.test(value)) {
+        if (!Utils.TEL_REG_EXR.test(trimmedValue)) {
           return CustomTextFieldErrors.TelFormat;
         }
         break;
       case TextFieldTypes.PersonalIdentityCode:
-        if (!isValidFinnishPIC(value)) {
+        if (!isValidFinnishPIC(trimmedValue)) {
           return CustomTextFieldErrors.PersonalIdentityCodeFormat;
         }
         break;

--- a/src/test/java/fi/oph/akt/api/translator/TranslatorControllerTest.java
+++ b/src/test/java/fi/oph/akt/api/translator/TranslatorControllerTest.java
@@ -51,9 +51,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyFirstName() throws Exception {
+  public void testContactRequestWithBlankFirstName() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("firstName", "");
+    data.put("firstName", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }
@@ -67,9 +67,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyLastName() throws Exception {
+  public void testContactRequestWithBlankLastName() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("lastName", "");
+    data.put("lastName", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }
@@ -83,9 +83,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyEmail() throws Exception {
+  public void testContactRequestWithBlankEmail() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("email", "");
+    data.put("email", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }
@@ -107,9 +107,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyMessage() throws Exception {
+  public void testContactRequestWithBlankMessage() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("message", "");
+    data.put("message", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }
@@ -123,9 +123,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyFromLang() throws Exception {
+  public void testContactRequestWithBlankFromLang() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("fromLang", "");
+    data.put("fromLang", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }
@@ -139,9 +139,9 @@ class TranslatorControllerTest {
   }
 
   @Test
-  public void testContactRequestWithEmptyToLang() throws Exception {
+  public void testContactRequestWithBlankToLang() throws Exception {
     final JSONObject data = validContactRequestData();
-    data.put("toLang", "");
+    data.put("toLang", " ");
 
     postContactRequest(data).andExpect(status().isBadRequest());
   }


### PR DESCRIPTION
Tehty useisiin paikkoihin käyttöliittymää parannuksia tietojen tallettamiseen liittyen. Backendin päähän lisätty validaatiot, että yhteydenottopyynnöissä (pl. puhelinnumero) sekä virkailijoiden lähettämissä sähköposteissa kenttien tulee olla "blankoja" eli pelkät välilyönnit sisältönä ei kelpaa. DTO:iden validaatio @NotBlank kattaa myös sen, että arvo ei voi olla NULL.

Frontendin päähän lisätty onBlur-eventejä eri tietokentille niin, että kenttien sisällöille ajetaan `.trim()` kun fokus niistä poistuu. Lisäksi kääntäjän talletukseen (lisäys ja muokkaus) liittyen lisätty `APIUtils` alle logiikkaa, että frontend ei lähetä POST-pyyntöjen mukana sellaisia kenttiä, joiden arvo on tyhjä / null / undefined. Tämän myötä tietokantaan ei talleteta kentille tyhjiä stringejä, vaan nämä tallettuvat NULL-arvoilla ja näin myöskään unique constraintit esim. kääntäjän tapauksessa mailiosoitteen ja HETUn osalta eivät herjaa, jos kannassa useammalla kääntäjällä nämä tiedot eivät ole tiedossa.

Seuraavia tiketissä mainittuja asioita ei ole vielä toteutettu / en saanut toimimaan:
- Lisättäessä kaksi kääntäjää peräkkäin, ladataan kääntäjän lisätiedot-sivu viimeisimpänä talletetun kääntäjän sijaan sitä edeltäneen talletetun kääntäjän tiedoilla (vaikka URL:ssa juuri talletetun kääntäjän id) --> voi tehdä erillisessä taskissa
- Virkailijan etusivun toiminto “Tyhjennä valinnat” ei tyhjennä nimihakukentän arvoa (lisätty TODO-tänne, voi poistaa jos tehdään toisessa taskissa)
- Mailiosoitekenttien (input tyyppiä "email") trimmaus ei näy UI:ssa, kun fokus tällaisesta kentästä poistuu, mutta ilmeisesti POST-pyyntöjen mukana kulkee kuitenkin trimmattu data