### PR TITLE
OPHAKTKEH-312

### DIFF
--- a/src/main/reactjs/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/src/main/reactjs/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -67,6 +67,7 @@ export const PublicTranslatorFilters = ({
     errors: [],
   };
   const [filters, setFilters] = useState(defaultFiltersState);
+  const [searchButtonDisabled, setSearchButtonDisabled] = useState(true);
   const defaultValuesState: PublicTranslatorFilterValues = {
     fromLang: null,
     toLang: null,
@@ -119,6 +120,7 @@ export const PublicTranslatorFilters = ({
     } else {
       dispatch(addPublicTranslatorFilter(filters));
       setShowTable(true);
+      setSearchButtonDisabled(true);
     }
   };
 
@@ -138,12 +140,14 @@ export const PublicTranslatorFilters = ({
     dispatch(emptySelectedTranslators);
     scrollToSearch();
     setShowTable(false);
+    setSearchButtonDisabled(true);
   };
 
   const handleComboboxInputChange =
     (inputName: SearchFilter) =>
     ({}, newInputValue: string) => {
       setInputValues({ ...inputValues, [inputName]: newInputValue });
+      setSearchButtonDisabled(false);
     };
 
   const handleComboboxFilterChange =
@@ -169,6 +173,7 @@ export const PublicTranslatorFilters = ({
         setValues((prevState) => ({ ...prevState, [filterName]: value }));
       }
       dispatch(removePublicTranslatorFilterError(filterName));
+      setSearchButtonDisabled(false);
     };
 
   const handleTextFieldFilterChange =
@@ -176,12 +181,13 @@ export const PublicTranslatorFilters = ({
     (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const target = event.target as HTMLInputElement;
       setValues((prevState) => ({ ...prevState, [filterName]: target.value }));
-      debounce(() =>
+      debounce(() => {
         setFilters((prevState) => ({
           ...prevState,
           [filterName]: target.value,
-        }))
-      );
+        }));
+        setSearchButtonDisabled(false);
+      });
     };
 
   const getComboBoxAttributes = (fieldName: SearchFilter) => ({
@@ -194,7 +200,10 @@ export const PublicTranslatorFilters = ({
   });
 
   const handleKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key == KeyboardKey.Enter) handleSearchBtnClick();
+    if (event.key == KeyboardKey.Enter && !searchButtonDisabled) {
+      handleSearchBtnClick();
+      setSearchButtonDisabled(true);
+    }
   };
 
   const isLangFilterDisabled = selectedTranslators.length > 0;
@@ -310,6 +319,7 @@ export const PublicTranslatorFilters = ({
           </CustomButton>
         )}
         <CustomButton
+          disabled={searchButtonDisabled}
           data-testid="public-translator-filters__search-btn"
           color={Color.Secondary}
           variant={Variant.Contained}

--- a/src/main/reactjs/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
+++ b/src/main/reactjs/src/components/publicTranslator/filters/PublicTranslatorFilters.tsx
@@ -202,7 +202,6 @@ export const PublicTranslatorFilters = ({
   const handleKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key == KeyboardKey.Enter && !searchButtonDisabled) {
       handleSearchBtnClick();
-      setSearchButtonDisabled(true);
     }
   };
 

--- a/src/main/reactjs/src/tests/cypress/integration/public_translator.spec.ts
+++ b/src/main/reactjs/src/tests/cypress/integration/public_translator.spec.ts
@@ -64,23 +64,7 @@ describe('PublicTranslatorFilters', () => {
     onToast.expectText('Voit valita vain yhden kieliparin yhteydenottoon');
   });
 
-  it('it should show a toast notification when language pair is defined, a translator is selected, and user tries to change to lang', () => {
-    onPublicTranslatorFilters.filterByLanguagePair('suomi', 'ruotsi');
-    onPublicTranslatorsListing.clickTranslatorRow('1940');
-    onPublicTranslatorFilters.clickToLang();
-
-    onToast.expectText('Voit valita vain yhden kieliparin yhteydenottoon');
-  });
-
-  it('it should show a toast notification when language pair is defined, a translator is selected, and user tries to change to lang', () => {
-    onPublicTranslatorFilters.filterByLanguagePair('suomi', 'ruotsi');
-    onPublicTranslatorsListing.clickTranslatorRow('1940');
-    onPublicTranslatorFilters.clickToLang();
-
-    onToast.expectText('Voit valita vain yhden kieliparin yhteydenottoon');
-  });
-
-  it.only('it should enable / disable search button correctly', () => {
+  it('it should enable / disable search button correctly', () => {
     onPublicTranslatorFilters.expectSearchButtonTo('be.disabled');
     onPublicTranslatorFilters.selectFromLangByName('suomi');
     onPublicTranslatorFilters.expectSearchButtonTo('be.enabled');

--- a/src/main/reactjs/src/tests/cypress/integration/public_translator.spec.ts
+++ b/src/main/reactjs/src/tests/cypress/integration/public_translator.spec.ts
@@ -71,4 +71,28 @@ describe('PublicTranslatorFilters', () => {
 
     onToast.expectText('Voit valita vain yhden kieliparin yhteydenottoon');
   });
+
+  it('it should show a toast notification when language pair is defined, a translator is selected, and user tries to change to lang', () => {
+    onPublicTranslatorFilters.filterByLanguagePair('suomi', 'ruotsi');
+    onPublicTranslatorsListing.clickTranslatorRow('1940');
+    onPublicTranslatorFilters.clickToLang();
+
+    onToast.expectText('Voit valita vain yhden kieliparin yhteydenottoon');
+  });
+
+  it.only('it should enable / disable search button correctly', () => {
+    onPublicTranslatorFilters.expectSearchButtonTo('be.disabled');
+    onPublicTranslatorFilters.selectFromLangByName('suomi');
+    onPublicTranslatorFilters.expectSearchButtonTo('be.enabled');
+    onPublicTranslatorFilters.emptySearch();
+    onPublicTranslatorFilters.expectSearchButtonTo('be.disabled');
+    onPublicTranslatorFilters.fillOutName('aaltonen a');
+    onPublicTranslatorFilters.expectSearchButtonTo('be.enabled');
+    onPublicTranslatorFilters.search();
+    onPublicTranslatorFilters.expectSearchButtonTo('be.disabled');
+    onPublicTranslatorFilters.fillOutTown('Helsinki');
+    onPublicTranslatorFilters.expectSearchButtonTo('be.enabled');
+    onPublicTranslatorFilters.enterKeyOnTown();
+    onPublicTranslatorFilters.expectSearchButtonTo('be.disabled');
+  });
 });

--- a/src/main/reactjs/src/tests/cypress/support/page-objects/publicTranslatorFilters.ts
+++ b/src/main/reactjs/src/tests/cypress/support/page-objects/publicTranslatorFilters.ts
@@ -44,6 +44,18 @@ class PublicTranslatorFilters {
     this.search();
   }
 
+  fillOutName(name: string) {
+    this.elements.name().type(name);
+  }
+
+  fillOutTown(town: string) {
+    this.elements.town().type(town);
+  }
+
+  enterKeyOnTown() {
+    this.elements.town().type('{enter}');
+  }
+
   emptySearch() {
     this.elements.empty().click();
   }
@@ -58,6 +70,10 @@ class PublicTranslatorFilters {
 
   clickToLang() {
     this.elements.toLang().click();
+  }
+
+  expectSearchButtonTo(assert: string) {
+    this.elements.search().should(assert);
   }
 
   expectSeachBtnText(text: string) {


### PR DESCRIPTION
Julkisen puolen kääntäjähaun hakunapin enablonti / disablointi päivitys.

Tällä hetkellä hyväksytyt edge-caset:

1. Käyttäjä painaa enteriä ennenkuin debounce timer (300ms) on ehtinyt mennä umpeen -> hakutulokset eivät päivity mutta hae nappi jää aktiiviseksi, jolloin joko enter-painalluksella tai klikkauksella saadaan tulokset näkyviin.
2. Jos filttereiden arvoa muuttaa mutta palauttaa ne takaisin arvoihin mitä ne oli edellisen haun aikaan, haku nappi on aktiivinen ja palauttaa samat hakutulokset kuin aikaisemmin. 